### PR TITLE
Switch to 0.16.0

### DIFF
--- a/include/ebpf_ntos_hooks.h
+++ b/include/ebpf_ntos_hooks.h
@@ -42,7 +42,7 @@ process_hook_t(process_md_t* context);
 // Process helper functions.
 #define PROCESS_EXT_HELPER_FN_BASE 0xFFFF
 
-#ifndef __doxygen
+#if !defined(__doxygen) && !defined(EBPF_HELPER)
 #define EBPF_HELPER(return_type, name, args) typedef return_type(*name##_t) args
 #endif
 

--- a/libs/store_helper/user/ebpf_store_helper_um.vcxproj
+++ b/libs/store_helper/user/ebpf_store_helper_um.vcxproj
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" />
+  <Import Project="..\..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -137,6 +137,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/libs/store_helper/user/packages.config
+++ b/libs/store_helper/user/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows" version="0.15.1" targetFramework="native" />
+  <package id="eBPF-for-Windows" version="0.16.0" targetFramework="native" />
 </packages>

--- a/ntosebpfext/sys/ntosebpfext.vcxproj
+++ b/ntosebpfext/sys/ntosebpfext.vcxproj
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props" Condition="Exists('..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" />
+  <Import Project="..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -241,6 +241,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/ntosebpfext/sys/packages.config
+++ b/ntosebpfext/sys/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows" version="0.15.1" targetFramework="native" />
+  <package id="eBPF-for-Windows" version="0.16.0" targetFramework="native" />
 </packages>

--- a/ntosebpfext/user/ntosebpfext_user.vcxproj
+++ b/ntosebpfext/user/ntosebpfext_user.vcxproj
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props" Condition="Exists('..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" />
+  <Import Project="..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -154,6 +154,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/ntosebpfext/user/packages.config
+++ b/ntosebpfext/user/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows" version="0.15.1" targetFramework="native" />
+  <package id="eBPF-for-Windows" version="0.16.0" targetFramework="native" />
 </packages>

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -6,7 +6,7 @@ $commands = @(
     "git submodule update --init --recursive",
     "cmake -G 'Visual Studio 17 2022' -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF",
     "nuget restore ntosebpfext.sln",
-    "packages\eBPF-for-Windows.0.15.1\build\native\bin\export_program_info.exe"
+    "packages\eBPF-for-Windows.0.16.0\build\native\bin\export_program_info.exe"
 )
 
 # Loop through each command and run them sequentially without opening a new window

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows" version="0.15.1" targetFramework="native" />
+  <package id="eBPF-for-Windows" version="0.16.0" targetFramework="native" />
 </packages>

--- a/scripts/setup_build/setup_build.vcxproj
+++ b/scripts/setup_build/setup_build.vcxproj
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props" Condition="Exists('..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" />
+  <Import Project="..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -228,6 +228,6 @@ copy "$(VC_CppRuntimeFilesPath_x64)\Microsoft.VC143.CRT" "$(OutDir)"</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tests/ntosebpfext_unit/ntosebpfext_unit.vcxproj
+++ b/tests/ntosebpfext_unit/ntosebpfext_unit.vcxproj
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props" Condition="Exists('..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" />
+  <Import Project="..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -149,6 +149,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tests/ntosebpfext_unit/packages.config
+++ b/tests/ntosebpfext_unit/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows" version="0.15.1" targetFramework="native" />
+  <package id="eBPF-for-Windows" version="0.16.0" targetFramework="native" />
 </packages>

--- a/tools/export_program_info/export_program_info.vcxproj
+++ b/tools/export_program_info/export_program_info.vcxproj
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props" Condition="Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props" Condition="Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -215,6 +215,6 @@ $(OutDir)ntos_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tools/export_program_info/packages.config
+++ b/tools/export_program_info/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows" version="0.15.1" targetFramework="native" />
+  <package id="eBPF-for-Windows" version="0.16.0" targetFramework="native" />
 </packages>

--- a/tools/process_monitor/packages.config
+++ b/tools/process_monitor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows" version="0.15.1" targetFramework="native" />
+  <package id="eBPF-for-Windows" version="0.16.0" targetFramework="native" />
 </packages>

--- a/tools/process_monitor/process_monitor.vcxproj
+++ b/tools/process_monitor/process_monitor.vcxproj
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props" Condition="Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props" Condition="Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -174,6 +174,6 @@ $(Outdir)ntos_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\eBPF-for-Windows.0.15.1\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\eBPF-for-Windows.0.16.0\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>


### PR DESCRIPTION
## Description

This pull request primarily involves updating the eBPF-for-Windows package from version 0.15.1 to 0.16.0 across multiple project files. Additionally, there is a minor change in the `include/ebpf_ntos_hooks.h` file to modify the condition for defining `EBPF_HELPER`.

Updates to eBPF-for-Windows package:

* `libs/store_helper/user/ebpf_store_helper_um.vcxproj`, `ntosebpfext/sys/ntosebpfext.vcxproj`, `ntosebpfext/user/ntosebpfext_user.vcxproj`, `scripts/setup_build/setup_build.vcxproj`, `tests/ntosebpfext_unit/ntosebpfext_unit.vcxproj`, `tools/export_program_info/export_program_info.vcxproj`, and `tools/process_monitor/process_monitor.vcxproj`: Updated the import project path to reflect the new version of the eBPF-for-Windows package. [[1]](diffhunk://#diff-a4102127e9f6021c978e83fb41d2ed9b4184969dad7cbde6d47940cb54d96b4dL7-R7) [[2]](diffhunk://#diff-ee9a1345ff678305197dd17fbe80c076429ad65ead087dc858411364ceaaff38L7-R7) [[3]](diffhunk://#diff-4bc3acc41258057027fa44eb91af63a3c22342e478ef6127f5531b488e24b454L7-R7) [[4]](diffhunk://#diff-fba898dae408066a5eb49d8a73ac332ce9cf08842afa394e7f8416b2b7a27e24L7-R7) [[5]](diffhunk://#diff-4493a7c571a9a90c82700350f8814705de958ded0a6980c717bb8808cc25ce46L7-R7) [[6]](diffhunk://#diff-89f2fb43211d88943131c99d17f4ea3f99d32aed85791980c0a6ec2fba5ac73eL7-R7) [[7]](diffhunk://#diff-87183e48097dbbbee23695ba14f270a636261cfa6f9fbbdbb702da70aa011ce8L7-R7)
* `libs/store_helper/user/packages.config`, `ntosebpfext/sys/packages.config`, `ntosebpfext/user/packages.config`, `scripts/setup_build/packages.config`, `tests/ntosebpfext_unit/packages.config`, `tools/export_program_info/packages.config`, and `tools/process_monitor/packages.config`: Updated the eBPF-for-Windows package version in the packages configuration.
* [`scripts/initialize_repo.ps1`](diffhunk://#diff-d54cd5dd484e429d1705c7acfa156427524b5eb7c90fa2b8e7b91dbce9f538f2L9-R9): Updated the path to the `export_program_info.exe` executable to reflect the new version of the eBPF-for-Windows package.

Minor code modification:

* [`include/ebpf_ntos_hooks.h`](diffhunk://#diff-9a7747cac93a4fbc69bf67be53aa46851eadf48a58f60522c564f07c872bc2bbL45-R45): Modified the condition for defining `EBPF_HELPER` to exclude when `EBPF_HELPER` is already defined.

## Testing

CI/CD

## Documentation

No.

## Installation

N/A
