### PR TITLE
Add test for process_monitor.exe tool

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,19 +69,18 @@ jobs:
       leak_detection: true
 
   # Process_Monitor test
-  # Disabled until https://github.com/microsoft/ebpf-for-windows/issues/3484 is fixed and a new release is available.
-  # process_monitor:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: process_monitor
-  #     pre_test: powershell .\Install-eBpfForWindows.ps1 0.15.1
-  #     test_command: powershell .\Test-ProcessMonitor.ps1
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     capture_etw: true
+  process_monitor:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: process_monitor
+      pre_test: powershell .\Install-eBpfForWindows.ps1 0.16.0
+      test_command: powershell .\Test-ProcessMonitor.ps1
+      build_artifact: Build-x64
+      environment: windows-2022
+      capture_etw: true
 
   ossar:
     # Always run this job.


### PR DESCRIPTION
## Description

This pull request primarily includes changes to the CI/CD workflow configuration in the `.github/workflows/cicd.yml` file. The key change is the re-enabling of the `process_monitor` job, which was previously disabled due to an issue.

* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L72-R83): The `process_monitor` job has been re-enabled in the CI/CD workflow. It was previously disabled due to an issue, which has now been resolved. The `pre_test` command has been updated to use version `0.16.0` of `Install-eBpfForWindows.ps1`.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
