### PR TITLE
Derive device name from PROVIDER_NAME

### DIFF
--- a/libs/ebpf_ext/ebpf_ext_drv.c
+++ b/libs/ebpf_ext/ebpf_ext_drv.c
@@ -17,7 +17,11 @@
 #include <wdf.h>
 #pragma warning(pop)
 
-#define EBPF_EXT_DEVICE_NAME L"\\Device\\EbpfExt"
+#define CONCATENATE_STRING(x, y) x##y
+
+#define EBPF_EXT_DEVICE_NAME_TEMPLATE(PROVIDER_NAME) L"\\device\\ebpf_ext_" L#PROVIDER_NAME
+
+#define EBPF_EXT_DEVICE_NAME EBPF_EXT_DEVICE_NAME_TEMPLATE(PROVIDER_NAME)
 
 // Driver global variables
 static WDFDEVICE _ebpf_ext_device = NULL;


### PR DESCRIPTION
## Description

This pull request includes a change in the `libs/ebpf_ext/ebpf_ext_drv.c` file that modifies the definition of `EBPF_EXT_DEVICE_NAME`. Previously, this macro was defined as a static string. The change introduces a new macro, `EBPF_EXT_DEVICE_NAME_TEMPLATE`, which takes a provider name as a parameter and constructs the device name string. This allows for more flexibility in naming devices. The `EBPF_EXT_DEVICE_NAME` macro now uses this template macro to define its value.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
