### PR TITLE
Fix ODR violation

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -90,7 +90,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: neteventebpfext unit tests
-      pre_test: powershell -file .\Install-eBpfForWindows.ps1 0.17.0
+      pre_test: powershell -file .\bin\process_monitor.Tests\win-x64\Install-eBpfForWindows.ps1 0.17.0
       test_command: .\neteventebpfext_unit.exe -d yes
       build_artifact: Build-x64
       environment: windows-2022

--- a/tests/neteventebpfext/netevent_sim/netevent_npi_client.h
+++ b/tests/neteventebpfext/netevent_sim/netevent_npi_client.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "ebpf_windows.h"
 
 // Specific Event type to the neteventebpfext extension.
 typedef struct
@@ -12,17 +13,6 @@ typedef struct
                                    ///< the memory range).
 } netevent_event_info_t;
 typedef void (*netevent_push_event)(netevent_event_info_t*);
-
-// Header of an eBPF extension data structure.
-// Every eBPF extension data structure must start with this header.
-// New fields can be added to the end of an eBPF extension data structure
-// without breaking backward compatibility. The version field must be
-// updated only if the new data structure is not backward compatible.
-typedef struct _ebpf_extension_header
-{
-    UINT16 version; ///< Version of the extension data structure.
-    size_t size;    ///< Size of the extension data structure.
-} ebpf_extension_header_t;
 
 // This is the type definition for the eBPF helper function addresses
 // when version is EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION.

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj
@@ -3,6 +3,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\eBPF-for-Windows.0.17.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.17.0\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -165,7 +166,15 @@
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
+  <ImportGroup Label="ExtensionTargets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.17.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.17.0\build\native\ebpf-for-windows.props'))" />
+  </Target>
 </Project>

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj.filters
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj.filters
@@ -13,4 +13,7 @@
     <ClInclude Include="netevent_npi_client.h" />
     <ClInclude Include="netevent_types.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/tests/neteventebpfext/netevent_sim/packages.config
+++ b/tests/neteventebpfext/netevent_sim/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="eBPF-for-Windows" version="0.17.0" targetFramework="native" />
+</packages>


### PR DESCRIPTION
## Description

This pull request includes a change in the `.github/workflows/cicd.yml` file. The change modifies the `pre_test` command under `jobs:` to use a new path for the `Install-eBpfForWindows.ps1` script. This script is now located in the `.\bin\process_monitor.Tests\win-x64 directory.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
