### PR TITLE
Add support for very long command lines in ntosebpfext process data

### DIFF
--- a/tests/process_monitor.Tests/ProcessMonitorTests.cs
+++ b/tests/process_monitor.Tests/ProcessMonitorTests.cs
@@ -79,13 +79,31 @@ public class ProcessMonitorTests
         Assert.IsTrue(destroyedArgs.ExitTime - createdArgs.CreateTime < TimeSpan.FromSeconds(4));
     }
 
+    [TestMethod]
+    public async Task VeryLongCommandLinesArriveIntact()
+    {
+        var expectedCreatingThreadId = GetCurrentThreadId();
+        var longArgs = new string('a', 5000) + 'b';
+        (var createdArgs, var destroyedArgs) = await RunProcessAndWaitForEventsAsync("cmd.exe", $"/c echo {longArgs}");
+
+        // The parent should be our own process
+        Assert.AreEqual((uint)Environment.ProcessId, createdArgs.ParentProcessId);
+        Assert.AreEqual((uint)Environment.ProcessId, createdArgs.CreatingProcessId);
+        Assert.AreEqual(expectedCreatingThreadId, createdArgs.CreatingThreadId);
+        Assert.AreEqual($"\"cmd.exe\" /c echo {longArgs}", createdArgs.CommandLine);
+
+        Assert.AreEqual(createdArgs.ImageFileName, destroyedArgs.ImageFileName);
+        Assert.AreEqual(createdArgs.CommandLine, destroyedArgs.CommandLine);
+        Assert.AreEqual(0u, destroyedArgs.ExitCode);
+    }
+
     private static async Task<(ProcessCreatedEventArgs created, ProcessDestroyedEventArgs destroyed)>
         RunProcessAndWaitForEventsAsync(string exeName, string arguments)
     {
         using var pm = new ProcessMonitor(LoggerFactory.CreateLogger<ProcessMonitor>());
 
         var processDestoryHappened = new ManualResetEvent(false);
-        var cmdEchoTestPID = 0u;
+        var testPID = 0u;
         ProcessCreatedEventArgs createdArgs = default;
         ProcessDestroyedEventArgs destroyedArgs = default;
 
@@ -94,14 +112,14 @@ public class ProcessMonitorTests
             if (e.ImageFileName.EndsWith(exeName, StringComparison.Ordinal) &&
                 e.CommandLine.Contains($"\"{exeName}\" {arguments}", StringComparison.Ordinal))
             {
-                cmdEchoTestPID = e.ProcessId;
+                testPID = e.ProcessId;
                 createdArgs = e;
             }
         };
 
         pm.ProcessDestroyed += (sender, e) =>
         {
-            if (e.ProcessId == cmdEchoTestPID)
+            if (e.ProcessId == testPID)
             {
                 destroyedArgs = e;
                 processDestoryHappened.Set();

--- a/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
+++ b/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
@@ -147,7 +147,7 @@ namespace process_monitor.Library
 
         private static unsafe string GetStringFromBpfMapFD(int mapFD, process_info_t* evt)
         {
-            Span<byte> utf8BytesOnStack = stackalloc byte[1024];
+            Span<byte> utf8BytesOnStack = stackalloc byte[32 * 1024]; // 32 KB is the size of a UNICODE_STRING
 
             var addrOfPID = (byte*)evt + process_info_t_process_id_offset;
             var byteSpanOfPID = new Span<byte>(addrOfPID, sizeof(uint));

--- a/tools/process_monitor_bpf/process_monitor.c
+++ b/tools/process_monitor_bpf/process_monitor.c
@@ -72,7 +72,7 @@ struct
 // would complain when the function is actually defined below.
 process_hook_t ProcessMonitor;
 
-__attribute__((always_inline)) void*
+inline __attribute__((always_inline)) void*
 get_scratch_space()
 {
     uint64_t current_pid_tgid_key = bpf_get_current_pid_tgid();


### PR DESCRIPTION
## Description
Previously we were limited to a few hundred characters for command lines.  This isn't long enough in many cases - such as `cl.exe` compiler invocations that have long include paths on them.  This uses the new support in 0.17 to help with marshaling long strings, so I allow up to 32k characters now which I believe is the maximum possible on Windows because `UNICODE_STRING` has a `USHORT MaximumLength` and that is the byte count, so character count is "max USHORT / 2" or 32k.

## Testing
Added a test that verifies a process with very long arguments (>5k characters) comes through as expected.

## Documentation
No docs need updated AFAIK.

## Installation
No installer impact.
