### PR TITLE
Change ntosebpfext command lines and image file names from UTF-8 to UTF-16

### DIFF
--- a/include/ebpf_ntos_hooks.h
+++ b/include/ebpf_ntos_hooks.h
@@ -14,8 +14,8 @@ typedef enum _process_operation
 
 typedef struct _process_md
 {
-    uint8_t* command_start;            ///< Pointer to start of the command line as UTF-8 string.
-    uint8_t* command_end;              ///< Pointer to end of the command line as UTF-8 string.
+    uint8_t* command_start;            ///< Pointer to start of the command line as UTF-16 string.
+    uint8_t* command_end;              ///< Pointer to end of the command line as UTF-16 string.
     uint64_t process_id;               ///< Process ID.
     uint64_t parent_process_id;        ///< Parent process ID.
     uint64_t creating_process_id;      ///< Creating process ID.

--- a/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
+++ b/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
@@ -73,11 +73,11 @@ TEST_CASE("process_invoke", "[ntosebpfext]")
     usersime_invoke_process_creation_notify_routine(
         reinterpret_cast<PEPROCESS>(&fake_eprocess), (HANDLE)1, &create_info);
 
-    std::string test_command_line = std::string(
-        reinterpret_cast<char*>(client_context.process_context.command_start),
-        reinterpret_cast<char*>(client_context.process_context.command_end));
+    std::wstring test_command_line = std::wstring(
+        reinterpret_cast<wchar_t*>(client_context.process_context.command_start),
+        reinterpret_cast<wchar_t*>(client_context.process_context.command_end));
 
-    REQUIRE(test_command_line == std::string("notepad.exe foo.txt"));
+    REQUIRE(test_command_line == std::wstring(L"notepad.exe foo.txt"));
 
     REQUIRE(client_context.process_context.process_id == 1);
     REQUIRE((HANDLE)client_context.process_context.parent_process_id == create_info.ParentProcessId);
@@ -137,11 +137,11 @@ TEST_CASE("process exit codes", "[ntosebpfext]")
 
     usersime_set_process_exit_status_callback([](PEPROCESS process) -> NTSTATUS { return expectedExitCode; });
 
-    std::string test_command_line = std::string(
-        reinterpret_cast<char*>(client_context.process_context.command_start),
-        reinterpret_cast<char*>(client_context.process_context.command_end));
+    std::wstring test_command_line = std::wstring(
+        reinterpret_cast<wchar_t*>(client_context.process_context.command_start),
+        reinterpret_cast<wchar_t*>(client_context.process_context.command_end));
 
-    REQUIRE(test_command_line == std::string("notepad.exe foo.txt"));
+    REQUIRE(test_command_line == std::wstring(L"notepad.exe foo.txt"));
 
     REQUIRE(client_context.process_context.process_id == 1);
     REQUIRE((HANDLE)client_context.process_context.parent_process_id == create_info.ParentProcessId);
@@ -206,11 +206,11 @@ TEST_CASE("process create and exit times", "[ntosebpfext]")
     usersime_invoke_process_creation_notify_routine(
         reinterpret_cast<PEPROCESS>(&fake_eprocess), (HANDLE)1, &create_info);
 
-    std::string test_command_line = std::string(
-        reinterpret_cast<char*>(client_context.process_context.command_start),
-        reinterpret_cast<char*>(client_context.process_context.command_end));
+    std::wstring test_command_line = std::wstring(
+        reinterpret_cast<wchar_t*>(client_context.process_context.command_start),
+        reinterpret_cast<wchar_t*>(client_context.process_context.command_end));
 
-    REQUIRE(test_command_line == std::string("notepad.exe foo.txt"));
+    REQUIRE(test_command_line == std::wstring(L"notepad.exe foo.txt"));
 
     REQUIRE(client_context.process_context.process_id == 1);
     REQUIRE((HANDLE)client_context.process_context.parent_process_id == create_info.ParentProcessId);

--- a/tools/process_monitor_bpf/process_monitor.c
+++ b/tools/process_monitor_bpf/process_monitor.c
@@ -9,7 +9,11 @@
 #include "ebpf_ntos_hooks.h"
 
 #define IMAGE_PATH_SIZE (1024)
-#define COMMAND_SCRATCH_SIZE (32 * 1024) // 32k characters is the max char count that fits in a UNICODE_STRING
+
+// 64k bytes is the max byte count that fits in a UNICODE_STRING (because Length is a USHORT).  Exactly 64k seems
+// to be a little too high for eBPF, so we subtract a few bytes and the likelihood this actually truncates anything
+// important is pretty low.
+#define COMMAND_SCRATCH_SIZE ((64 * 1024) - 16)
 
 // Declare a per-CPU array to be used as scratch space.
 struct


### PR DESCRIPTION
## Description
Originally when `ntosebpfext` was created, there was a pretty low limit on the number of characters that could be marshalled through, so the strings from the kernel were converted to UTF-8 to pack more characters into the limited space.  But, with the recent PR (#76), we're now able to marshal much longer strings.  Rather than convert them to UTF-8, only to re-convert back to UTF-16 in user mode in many cases, we just pass the UTF-16 string the whole way through.

This reduces 2 string allocations during process create events as a happy little perf side-effect.

## Testing
I ran the existing tests locally.

## Documentation
No doc updates needed.

## Installation
No installer impact.
