### PR TITLE
Centralize which version of clang to use

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,9 @@
   <PropertyGroup Condition="'$(AddressSanitizer)'=='True' And '$(MSBuildProjectExtension)'!='.csproj'">
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
+    <PropertyGroup>
+    <ClangExec>"$(VsInstallRoot)\VC\Tools\Llvm\bin\clang.exe"</ClangExec>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/tools/netevent_monitor/netevent_monitor.vcxproj
+++ b/tools/netevent_monitor/netevent_monitor.vcxproj
@@ -161,7 +161,7 @@ $(Outdir)netevent_ebpf_ext_export_program_info.exe</Command>
       <FileType>CppCode</FileType>
       <Outputs>$(OutputPath)netevent_monitor.o</Outputs>
       <Command>
-        clang $(ClangFlags) $(ClangIncludes) -I$(SolutionDir)include -c bpf\netevent_monitor.c -o $(OutputPath)netevent_monitor.o
+        $(ClangExec) $(ClangFlags) $(ClangIncludes) -I$(SolutionDir)include -c bpf\netevent_monitor.c -o $(OutputPath)netevent_monitor.o
         pushd $(OutDir)
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(EbpfBinPath)\Convert-BpfToNative.ps1 -FileName %(Filename) -Type netevent_monitor -IncludeDir $(EbpfIncludePath) -Platform $(Platform) -Configuration $(Configuration)
         popd

--- a/tools/process_monitor_bpf/process_monitor_bpf.vcxproj
+++ b/tools/process_monitor_bpf/process_monitor_bpf.vcxproj
@@ -92,7 +92,7 @@ $(Outdir)ntos_ebpf_ext_export_program_info.exe</Command>
       <FileType>CppCode</FileType>
       <Outputs>$(OutputPath)process_monitor.o</Outputs>
       <Command>
-        clang $(ClangFlags) $(ClangIncludes) -I$(SolutionDir)include -c process_monitor.c -o $(OutputPath)process_monitor.o
+        $(ClangExec) $(ClangFlags) $(ClangIncludes) -I$(SolutionDir)include -c process_monitor.c -o $(OutputPath)process_monitor.o
         pushd $(OutDir)
         powershell -NonInteractive -ExecutionPolicy Unrestricted $(EbpfBinPath)\Convert-BpfToNative.ps1 -FileName %(Filename) -Type process -IncludeDir $(EbpfIncludePath) -Platform $(Platform) -Configuration $(Configuration)
         popd


### PR DESCRIPTION
## Description

This pull request focuses on centralizing the Clang executable path configuration and updating the project files to use this new configuration. The main changes include defining a new property for the Clang executable path and updating the build commands to use this property.

Configuration updates:

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR19-R21): Added a new property `ClangExec` to define the path to the Clang executable.

Build command updates:

* [`tools/netevent_monitor/netevent_monitor.vcxproj`](diffhunk://#diff-67ce0f27f1eb3b87531d5c5bddc78f4fd2b10a961c2420f4a8a7f6690af84490L164-R164): Modified the build command to use the new `ClangExec` property for compiling `netevent_monitor.c`.
* [`tools/process_monitor_bpf/process_monitor_bpf.vcxproj`](diffhunk://#diff-7db0b95bb1328f76e5bcba77a648e015def2be8800ed92df9acf5da3b1c84c65L95-R95): Modified the build command to use the new `ClangExec` property for compiling `process_monitor.c`.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
