### PR TITLE
 Update .NET SDK to latest patch version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.000",
+    "version": "8.0.403",
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
## Description

This change updates to the latest patch version for the .NET SDK which contains the latest security fixes.
Note that even though global.json does configure rollForward, roll forward will allow for the build to pass when using a different SDK. 
CI in many cases installs exactly what is in the global.json, so making sure that your build requires the latest patch version ensures that CI is compliant with those vulnerabilities.

## Testing

CI/CD

## Documentation

NA

## Installation

NA