### PR TITLE
Switch to nuget WDK

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -108,33 +108,15 @@ jobs:
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
-
-    - name: Setup choco cache folder
-      # Set the choco cache to a local folder so that it can be cached.
-      if: steps.skip_check.outputs.should_skip != 'true'
-      id: choco-cache
-      run: |
-        mkdir ${{github.workspace}}\choco_cache
-        choco config set --name cacheLocation --value ${{github.workspace}}\choco_cache
-
-    - name: Cache choco packages
-      # Add cache entry for any choco packages that are installed.
-      # The cache key is based on the hash of this file so if any choco packages are added or removed, the cache will be invalidated.
-      if: steps.skip_check.outputs.should_skip != 'true'
-      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
-      env:
-        cache-name: cache-choco-packages
       with:
-        path: ${{github.workspace}}\choco_cache
-        key: ${{ hashFiles('.github/workflows/reusable-build.yml') }}
+        msbuild-architecture: x64
 
-    - name: Install tools
+    - name: Check clang version
       if: steps.skip_check.outputs.should_skip != 'true'
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
-        choco install -y llvm --version 11.0.1 --allow-downgrade
-        echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         where clang.exe
+        clang -v
 
     - name: Install .NET 8 SDK
       if: steps.skip_check.outputs.should_skip != 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,6 @@ To build locally, ensure your environment is set up:
 
 1. Install Visual Studio 2022 with at least the "Desktop development with C++" and ".NET desktop development" workloads
 1. Install the .NET 8 SDK from https://dotnet.microsoft.com/en-us/download/dotnet/8.0
-1. Install the Windows SDK 10.0.22621.0 with `winget install Microsoft.WindowsSDK.10.0.22621`
-1. Install the Windows DDK 10.0.22621.0 with `winget install Microsoft.WindowsWDK.10.0.22621`
 
 Then do one-time repo setup:
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
-  <Import Project="$(SolutionDir)wdk.props"/>
+  <Import Project="$(SolutionDir)wdk.props" Condition="'$(MSBuildProjectExtension)'!='.csproj'"/>
   <PropertyGroup Condition="'$(Analysis)'=='True' And '$(MSBuildProjectExtension)'!='.csproj'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
@@ -18,7 +18,7 @@
   <PropertyGroup Condition="'$(AddressSanitizer)'=='True' And '$(MSBuildProjectExtension)'!='.csproj'">
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
-    <PropertyGroup>
+  <PropertyGroup>
     <ClangExec>"$(VsInstallRoot)\VC\Tools\Llvm\bin\clang.exe"</ClangExec>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <Import Project="$(SolutionDir)wdk.props"/>
   <PropertyGroup Condition="'$(Analysis)'=='True' And '$(MSBuildProjectExtension)'!='.csproj'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
@@ -32,7 +33,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <AdditionalOptions>/ZH:SHA_256 /we4062 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(WindowsSdkDir)Include\10.0.22621.0\km;$(SolutionDir)external\ebpf-verifier\build\packages\boost\lib\native\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(WdkContentRoot)\Include\$(WindowsTargetPlatformVersion)\km;;$(SolutionDir)external\ebpf-verifier\build\packages\boost\lib\native\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <CETCompat>true</CETCompat>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
-  <Import Project="$(SolutionDir)wdk.props" Condition="'$(MSBuildProjectExtension)'!='.csproj'"/>
+  <Import Project="$(SolutionDir)wdk.props" Condition="'$(MSBuildProjectExtension)'=='.vcxproj'"/>
   <PropertyGroup Condition="'$(Analysis)'=='True' And '$(MSBuildProjectExtension)'!='.csproj'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <DisableAnalyzeExternal>true</DisableAnalyzeExternal>

--- a/ebpf_extensions/neteventebpfext/sys/neteventebpfext.vcxproj
+++ b/ebpf_extensions/neteventebpfext/sys/neteventebpfext.vcxproj
@@ -48,7 +48,6 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>EbpfDriver</RootNamespace>
     <ProjectName>neteventebpfext</ProjectName>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/ebpf_extensions/neteventebpfext/sys/neteventebpfext.vcxproj
+++ b/ebpf_extensions/neteventebpfext/sys/neteventebpfext.vcxproj
@@ -131,7 +131,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO;NDEBUG</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Platform)\$(ConfigurationName)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -154,7 +154,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Platform)\$(ConfigurationName)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -176,7 +176,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Platform)\$(ConfigurationName)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -198,7 +198,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Platform)\$(ConfigurationName)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>

--- a/ebpf_extensions/neteventebpfext/user/neteventebpfext_user.vcxproj
+++ b/ebpf_extensions/neteventebpfext/user/neteventebpfext_user.vcxproj
@@ -24,7 +24,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{AAAB234B-F0E9-4326-91E8-87B98367ACC1}</ProjectGuid>
     <RootNamespace>neteventebpfextunit</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>neteventebpfext_user</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
+++ b/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
@@ -32,7 +32,6 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>EbpfDriver</RootNamespace>
     <ProjectName>ntosebpfext</ProjectName>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
+++ b/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
@@ -95,7 +95,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO;NDEBUG</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Platform)\$(ConfigurationName)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -117,7 +117,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Platform)\$(ConfigurationName)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>

--- a/ebpf_extensions/ntosebpfext/user/ntosebpfext_user.vcxproj
+++ b/ebpf_extensions/ntosebpfext/user/ntosebpfext_user.vcxproj
@@ -20,7 +20,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{630bb78f-6211-41d8-8e3a-096e22e169ef}</ProjectGuid>
     <RootNamespace>ntosebpfextunit</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>ntosebpfext_user</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -1,4 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="eBPF-for-Windows" version="0.18.0" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2161" targetFramework="native" />
 </packages>

--- a/scripts/setup_build/setup_build.vcxproj
+++ b/scripts/setup_build/setup_build.vcxproj
@@ -45,7 +45,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{231ee32b-eba4-4fe5-a55b-db18f539d403}</ProjectGuid>
     <RootNamespace>setupbuild</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj
@@ -118,7 +118,7 @@
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -132,7 +132,7 @@
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(SDK_LIB_PATH)\uuid.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">

--- a/tests/neteventebpfext/neteventebpfext_unit/neteventebpfext_unit.vcxproj
+++ b/tests/neteventebpfext/neteventebpfext_unit/neteventebpfext_unit.vcxproj
@@ -24,7 +24,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{32DA760D-1A43-4940-BECE-59AE0B817ED9}</ProjectGuid>
     <RootNamespace>neteventebpfextunit</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>neteventebpfext_unit</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/tests/ntosebpfext/ntosebpfext_unit/ntosebpfext_unit.vcxproj
+++ b/tests/ntosebpfext/ntosebpfext_unit/ntosebpfext_unit.vcxproj
@@ -20,7 +20,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{e619b985-44b3-4292-a585-5cd0c4315ed3}</ProjectGuid>
     <RootNamespace>ntosebpfextunit</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>ntosebpfext_unit</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/tools/netevent_ebpf_ext_export_program_info/netevent_ebpf_ext_export_program_info.vcxproj
+++ b/tools/netevent_ebpf_ext_export_program_info/netevent_ebpf_ext_export_program_info.vcxproj
@@ -32,7 +32,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{61896FC2-D314-468E-887B-7B1EBC7F0FEB}</ProjectGuid>
     <RootNamespace>encodeprograminfo</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>netevent_ebpf_ext_export_program_info</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -115,7 +114,7 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser;$(WdkContentRoot)\Include\$(WindowsTargetPlatformVersion)\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -135,7 +134,7 @@ $(OutDir)netevent_ebpf_ext_export_program_info.exe</Command>
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser;$(WdkContentRoot)\Include\$(WindowsTargetPlatformVersion)\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -155,7 +154,7 @@ $(OutDir)netevent_ebpf_ext_export_program_info.exe</Command>
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser;$(WdkContentRoot)\Include\$(WindowsTargetPlatformVersion)\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -175,7 +174,7 @@ $(OutDir)netevent_ebpf_ext_export_program_info.exe</Command>
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser;$(WdkContentRoot)\Include\$(WindowsTargetPlatformVersion)\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -197,7 +196,7 @@ $(OutDir)netevent_ebpf_ext_export_program_info.exe</Command>
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)include;$(SolutionDir)libs\include\user;$(SolutionDir)external\usersim\inc;$(SolutionDir)include\user;$(SolutionDir)neteventebpfext;$(SolutionDir)neteventebpfext\user;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winuser;$(WdkContentRoot)\Include\$(WindowsTargetPlatformVersion)\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tools/netevent_monitor/netevent_monitor.vcxproj
+++ b/tools/netevent_monitor/netevent_monitor.vcxproj
@@ -28,7 +28,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{1132BFD8-EECA-4372-B08E-D349D86FE616}</ProjectGuid>
     <RootNamespace>netevent_monitor</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ClangFlags>-g -target bpf -O2 -Werror</ClangFlags>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/tools/ntos_ebpf_ext_export_program_info/ntos_ebpf_ext_export_program_info.vcxproj
+++ b/tools/ntos_ebpf_ext_export_program_info/ntos_ebpf_ext_export_program_info.vcxproj
@@ -20,7 +20,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{fa9bb88d-8259-40c1-9422-bdedf9e9ce68}</ProjectGuid>
     <RootNamespace>encodeprograminfo</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>ntos_ebpf_ext_export_program_info</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/tools/onebranch/onebranch.vcxproj
+++ b/tools/onebranch/onebranch.vcxproj
@@ -27,8 +27,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{988a1731-f674-472f-8063-84d6dea8988d}</ProjectGuid>
     <RootNamespace>onebranch</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-  </PropertyGroup>
+    </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/tools/process_monitor_bpf/process_monitor_bpf.vcxproj
+++ b/tools/process_monitor_bpf/process_monitor_bpf.vcxproj
@@ -20,8 +20,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{3DBF8A96-3883-448A-8BD3-B8C913A27F09}</ProjectGuid>
     <RootNamespace>process_monitor</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <ClangFlags>-g -target bpf -O2 -Werror</ClangFlags>
+      <ClangFlags>-g -target bpf -O2 -Werror</ClangFlags>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/tools/utils/utils.vcxproj
+++ b/tools/utils/utils.vcxproj
@@ -19,8 +19,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{52440d8b-c623-48c4-a2a3-527245139e19}</ProjectGuid>
     <RootNamespace>utils</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-  </PropertyGroup>
+    </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/wdk.props
+++ b/wdk.props
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: MIT
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup>
+    <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WDKVersion>10.0.26100.2161</WDKVersion>
+  </PropertyGroup>
+
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props')" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props'))" />
+  </Target>
+</Project>

--- a/wdk.props
+++ b/wdk.props
@@ -16,13 +16,4 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets')" />
   </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.$(Platform).props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.WDK.$(Platform).$(WDKVersion)\build\native\Microsoft.Windows.WDK.$(Platform).props'))" />
-  </Target>
 </Project>


### PR DESCRIPTION
## Description

This pull request includes several changes primarily focused on updating project dependencies and configurations. The most significant changes involve the addition of new SDK and WDK packages, updates to project properties, and modifications to include directories and dependencies in various project files.

### Project Dependency Updates:

* Added multiple `Microsoft.Windows.SDK.CPP` and `Microsoft.Windows.WDK` packages to `scripts/setup_build/packages.config` to ensure compatibility with the latest Windows SDK and WDK versions.

### Configuration and Property Updates:

* Imported `wdk.props` in `Directory.Build.props` and updated the `AdditionalIncludeDirectories` to use `$(WdkContentRoot)` and `$(WindowsTargetPlatformVersion)`. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR7) [[2]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL35-R36)
* Added a new `wdk.props` file to define properties for the Windows target platform and WDK version, and to ensure the correct SDK and WDK packages are imported.

### Dependency Modifications:

* Removed `uuid.lib` from the `AdditionalDependencies` in several `.vcxproj` files, including `ebpf_extensions/neteventebpfext/sys/neteventebpfext.vcxproj`, `ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj`, and `tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj`. [[1]](diffhunk://#diff-63ef6aacf095674e53f6ca147409f2d0d9064821dc54e3d830252721c37203faL134-R134) [[2]](diffhunk://#diff-63ef6aacf095674e53f6ca147409f2d0d9064821dc54e3d830252721c37203faL157-R157) [[3]](diffhunk://#diff-63ef6aacf095674e53f6ca147409f2d0d9064821dc54e3d830252721c37203faL179-R179) [[4]](diffhunk://#diff-63ef6aacf095674e53f6ca147409f2d0d9064821dc54e3d830252721c37203faL201-R201) [[5]](diffhunk://#diff-d77d20a1730270a883dc131d0536e394b498159aebc60bbf38b4a98d97041b66L98-R98) [[6]](diffhunk://#diff-d77d20a1730270a883dc131d0536e394b498159aebc60bbf38b4a98d97041b66L120-R120) [[7]](diffhunk://#diff-0146e6efa4f2c804bf5d9513884e62b71b4afad847750d15587b2ae8dd3ab05bL121-R121) [[8]](diffhunk://#diff-0146e6efa4f2c804bf5d9513884e62b71b4afad847750d15587b2ae8dd3ab05bL135-R135)

## Testing

CI/CD

## Documentation

Yes.

## Installation

No.
