### PR TITLE
Fix netevent header structure

### DIFF
--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -80,7 +80,7 @@ typedef struct netevent_ext_function_addresses
 
 // Dispatch table for the client module's helper functions
 static const void* _ebpf_netevent_ext_helper_functions[] = {(void*)&_ebpf_netevent_push_event};
-const ebpf_helper_function_addresses_t _netevent_client_dispatch = {
+const netevent_ext_function_addresses_t _netevent_client_dispatch = {
     .header =
         {.version = EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION, .size = sizeof(netevent_ext_function_addresses_t)},
     .helper_function_count = EBPF_COUNT_OF(_ebpf_netevent_ext_helper_functions),

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -63,12 +63,26 @@ _netevent_ebpf_extension_detach_provider(_In_ HANDLE nmr_binding_handle);
 // Structures for attaching to NetEvent (as an NMR client)
 //
 
+typedef struct netevent_ext_header
+{
+    uint16_t version; ///< Version of the extension data structure.
+    size_t size;      ///< Size of the netevent function addresses structure.
+} netevent_ext_header_t;
+
+// This is the type definition for the netevent helper function addresses.
+// This type should be matched by the Netevent NMI provider.
+typedef struct netevent_ext_function_addresses
+{
+    netevent_ext_header_t header;
+    uint32_t helper_function_count;
+    uint64_t* helper_function_address;
+} netevent_ext_function_addresses_t;
+
 // Dispatch table for the client module's helper functions
 static const void* _ebpf_netevent_ext_helper_functions[] = {(void*)&_ebpf_netevent_push_event};
 const ebpf_helper_function_addresses_t _netevent_client_dispatch = {
     .header =
-        {.version = EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION,
-         .size = EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_SIZE},
+        {.version = EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION, .size = sizeof(netevent_ext_function_addresses_t)},
     .helper_function_count = EBPF_COUNT_OF(_ebpf_netevent_ext_helper_functions),
     .helper_function_address = (uint64_t*)_ebpf_netevent_ext_helper_functions};
 

--- a/tests/neteventebpfext/netevent_sim/netevent_npi_client.h
+++ b/tests/neteventebpfext/netevent_sim/netevent_npi_client.h
@@ -14,11 +14,16 @@ typedef struct
 } netevent_event_info_t;
 typedef void (*netevent_push_event)(netevent_event_info_t*);
 
-// This is the type definition for the eBPF helper function addresses
-// when version is EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION.
-typedef struct _ebpf_helper_function_addresses
+typedef struct netevent_ext_header
 {
-    ebpf_extension_header_t header;
-    UINT32 helper_function_count;
-    UINT64* helper_function_address;
-} ebpf_helper_function_addresses_t;
+    uint16_t version; ///< Version of the extension data structure.
+    size_t size;      ///< Size of the netevent function addresses structure.
+} netevent_ext_header_t;
+
+// This is the type definition for the netevent helper function addresses.
+typedef struct netevent_ext_function_addresses
+{
+    netevent_ext_header_t header;
+    uint32_t helper_function_count;
+    uint64_t* helper_function_address;
+} netevent_ext_function_addresses_t;

--- a/tests/neteventebpfext/netevent_sim/netevent_npi_provider.h
+++ b/tests/neteventebpfext/netevent_sim/netevent_npi_provider.h
@@ -23,8 +23,8 @@ typedef struct PROVIDER_REGISTRATION_CONTEXT_
 // Define the context structure for the provider module's binding to a client module
 typedef struct PROVIDER_BINDING_CONTEXT_
 {
-    HANDLE client_binding_handle;                            // Handle of the attached client
-    const ebpf_helper_function_addresses_t* client_dispatch; // Dispatch routines addresses of the attached client
-    PNPI_REGISTRATION_INSTANCE client_registration_instance; // Registration instance of the attached client
-    void* client_binding_context;                            // Binding context of the attached client
+    HANDLE client_binding_handle;                             // Handle of the attached client
+    const netevent_ext_function_addresses_t* client_dispatch; // Dispatch routines addresses of the attached client
+    PNPI_REGISTRATION_INSTANCE client_registration_instance;  // Registration instance of the attached client
+    void* client_binding_context;                             // Binding context of the attached client
 } PROVIDER_BINDING_CONTEXT;


### PR DESCRIPTION
## Description

Fixes #173 by adding separate header structure for netevent that does not depend on ebpf header.