### PR TITLE
Update .NET test packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,13 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Try to keep these in alphabetical order -->
-    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.4"/>
-    <PackageVersion Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.4"/>
+    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.4" />
+    <PackageVersion Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.4" />
     <PackageVersion Include="eBPF-for-Windows" Version="0.18.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.2.2" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.6.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

This pull request includes updates to the `Directory.Packages.props` file to upgrade several package versions. The most important changes are the version updates for the Microsoft.Extensions.Logging and MSTest packages.

Package version updates:

* [`Microsoft.Extensions.Logging.Abstractions`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L14-R18): Updated from version 8.0.0 to 9.0.0.
* [`Microsoft.Extensions.Logging.Console`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L14-R18): Updated from version 8.0.0 to 9.0.0.
* [`Microsoft.NET.Test.Sdk`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L14-R18): Updated from version 17.9.0 to 17.12.0.
* [`MSTest.TestAdapter`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L14-R18): Updated from version 3.2.2 to 3.6.4.
* [`MSTest.TestFramework`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L14-R18): Updated from version 3.2.2 to 3.6.4.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
