### PR TITLE
Add nuget.config to root when building on onebranch

### DIFF
--- a/scripts/onebranch/Nuget.config
+++ b/scripts/onebranch/Nuget.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: MIT
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="undock_PublicPackages" value="https://pkgs.dev.azure.com/microsoft/undock/_packaging/Undock_PublicPackages/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/scripts/onebranch/pre-build.ps1
+++ b/scripts/onebranch/pre-build.ps1
@@ -7,6 +7,12 @@ $scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 # Change the parent directory for the script directory
 Set-Location $scriptPath\..\..
 
-.\scripts\initialize_repo.ps1
+try {
+    Copy-Item .\scripts\onebranch\nuget.config .\nuget.config
+    .\scripts\initialize_repo.ps1
+}
+catch {
+    throw "Failed to initialize the repository."
+}
 
 Get-ChildItem -Path ./external -Filter *.dll -Recurse | Remove-Item


### PR DESCRIPTION
## Description

This pull request includes changes to the `scripts/onebranch` directory to improve the configuration and initialization process. The most important changes include adding a new `Nuget.config` file and updating the `pre-build.ps1` script to handle errors during repository initialization.

Configuration updates:

* [`scripts/onebranch/Nuget.config`](diffhunk://#diff-5e9e0d4958b664c5fadda650d499ca5762c306cd75c919b1edaa80da938eac82R1-R11): Added a new `Nuget.config` file to configure the package sources for the project.

Initialization script improvements:

* [`scripts/onebranch/pre-build.ps1`](diffhunk://#diff-201f8696433b57790b5086ecc8a95609ea467b0e18ba2882361c1015bc1ca90bR10-R16): Updated the script to copy the `Nuget.config` file and added error handling to provide a clear error message if repository initialization fails.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
