### PR TITLE
Organize nupkgs for publishing

### DIFF
--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -57,15 +57,13 @@ Set-Location $scriptPath\..\..
 $SolutionDir = Get-Location
 msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false .\tools\nuget\nuget.proj /t:Restore,Build,Pack
 
-# Copy the nupkg and msi to the output directory
-if ($OneBranchConfig -eq "Debug" -and $OneBranchArch -eq "x64") {
-    xcopy /y .\x64\Debug\*.nupkg .\build\bin\x64_Debug
-    Copy-BuildFolder -Configuration Debug -Arch x64
+$SourceNupkgPath = ".\$OneBranchArch\$OneBranchConfig\*.nupkg"
+# Copy the nupkg to the 'packages' subdirectory in the output directory (default used by onebranch pipelines to publish nupkgs)
+$DestinationNupkgPath = ".\build\bin\$OneBranchArch`_$OneBranchConfig\packages"
+
+if (-not (Test-Path -Path $DestinationNupkgPath)) {
+    New-Item -ItemType Directory -Path $DestinationNupkgPath
 }
-elseif ($OneBranchConfig -eq "Release" -and $OneBranchArch -eq "x64") {
-    xcopy /y .\x64\Release\*.nupkg .\build\bin\x64_Release
-    Copy-BuildFolder -Configuration Release -Arch x64
-}
-else {
-    throw ("Configuration $OneBranchConfig|$OneBranchArch is not supported.")
-}
+
+xcopy /y $SourceNupkgPath $DestinationNupkgPath
+Copy-BuildFolder -Configuration $OneBranchConfig -Arch $OneBranchArch

--- a/tools/nuget/nuget.proj
+++ b/tools/nuget/nuget.proj
@@ -5,7 +5,8 @@
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <OutputPath>$(MSBuildThisFileDirectory)..\..\$(Platform)\$(Configuration)</OutputPath>
-    <PackageId>eBPF-for-Windows.Extensions</PackageId>
+    <PackageId Condition="'$(Configuration)' == 'Release'">eBPF-for-Windows.Extensions</PackageId>
+    <PackageId Condition="'$(Configuration)' == 'Debug'">eBPF-for-Windows.Extensions.Debug</PackageId>
     <IsPackable>true</IsPackable>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>eBPF for Windows Contributors</Authors>


### PR DESCRIPTION
## Description

This change:

* Modifies the post-build script to copy the unsigned nupkgs to the packages subdirectory under build\bin\<arch>. This directory is monitored by internal pipelines to publish nuget packages.
* Updates the name of the core package to include the configuration in the generated name, for non-release configurations. eg. eBPF-for-Windows.Extensions.x64 for the "Release" configuration and eBPF-for-Windows.Extensions.Debug.x64 for the "Debug" configuration.

## Testing

Internal pipelines were run and confirmed to publish the packages as expected