### PR TITLE
Switch push locks to spin lock

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
   <!-- Select the best version of clang available. -->
   <!-- If $(VsInstallRoot)\VC\Tools\Llvm\bin\clang.exe exists, set ClangExe to that value -->
   <PropertyGroup Condition="Exists('$(VsInstallRoot)\VC\Tools\Llvm\bin\clang.exe')">
-    <ClangExec>$(VsInstallRoot)\VC\Tools\Llvm\bin\clang.exe</ClangExec>
+    <ClangExec>"$(VsInstallRoot)\VC\Tools\Llvm\bin\clang.exe"</ClangExec>
   </PropertyGroup>
   <!-- If $(ProgramFiles)\LLVM\bin\clang.exe exists, set ClangExe to that value -->
   <PropertyGroup Condition="Exists('$(ProgramFiles)\LLVM\bin\clang.exe')">
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <!-- If $(SolutionDir)packages\llvm.tools\clang.exe exists, set ClangExe to that value -->
   <PropertyGroup Condition="Exists('$(SolutionDir)packages\llvm.tools\clang.exe')">
-    <ClangExec>$(SolutionDir)packages\llvm.tools\clang.exe</ClangExec>
+    <ClangExec>"$(SolutionDir)packages\llvm.tools\clang.exe"</ClangExec>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -83,7 +83,7 @@ typedef struct netevent_ext_function_addresses
 static const void* _ebpf_netevent_ext_helper_functions[] = {(void*)&_ebpf_netevent_push_event};
 netevent_ext_function_addresses_t _netevent_client_dispatch = {
     .header = {.version = EBPF_NETEVENT_EXTENSION_VERSION, .size = sizeof(netevent_ext_function_addresses_t)},
-    .capture_type = NetevenCapture_Drop,
+    .capture_type = NeteventCapture_Drop,
     .helper_function_count = EBPF_COUNT_OF(_ebpf_netevent_ext_helper_functions),
     .helper_function_address = (uint64_t*)_ebpf_netevent_ext_helper_functions};
 
@@ -231,7 +231,7 @@ _netevent_ebpf_extension_netevent_on_client_attach(
 
     if (client_data != NULL && client_data->data != NULL) {
         attach_opts = (netevent_attach_opts_t*)client_data->data;
-        if ((attach_opts->capture_type >= NeteventCapture_All) && (attach_opts->capture_type <= NetevenCapture_None)) {
+        if ((attach_opts->capture_type >= NeteventCapture_All) && (attach_opts->capture_type <= NeteventCapture_None)) {
             _netevent_client_dispatch.capture_type = attach_opts->capture_type;
         } else {
             EBPF_EXT_LOG_MESSAGE(

--- a/include/ebpf_netevent_hooks.h
+++ b/include/ebpf_netevent_hooks.h
@@ -21,9 +21,9 @@ typedef struct _netevent_event_md
 typedef enum _netevent_capture_type
 {
     NeteventCapture_All = 1,
-    NetevenCapture_Flow,
-    NetevenCapture_Drop,
-    NetevenCapture_None
+    NeteventCapture_Flow,
+    NeteventCapture_Drop,
+    NeteventCapture_None
 } netevent_capture_type_t;
 
 typedef struct _netevent_attach_opts

--- a/libs/ebpf_ext/ebpf_ext_hook_provider.c
+++ b/libs/ebpf_ext/ebpf_ext_hook_provider.c
@@ -70,23 +70,25 @@ typedef struct _ebpf_extension_hook_provider
 #define RELEASE_PUSH_LOCK_EXCLUSIVE(lock) _RELEASE_PUSH_LOCK(lock, Exclusive)
 #define RELEASE_PUSH_LOCK_SHARED(lock) _RELEASE_PUSH_LOCK(lock, Shared)
 
-#define _ACQUIRE_SPIN_LOCK(lock, mode) \
-    {                                  \
-        KeEnterCriticalRegion();       \
-        ExAcquireSpinLock##mode(lock); \
-    }
+static inline KIRQL
+_acquire_spin_lock(EX_SPIN_LOCK* lock, bool exclusive)
+{
+    KeEnterCriticalRegion();
+    return exclusive ? ExAcquireSpinLockExclusive(lock) : ExAcquireSpinLockShared(lock);
+}
 
-#define _RELEASE_SPIN_LOCK(lock, mode) \
-    {                                  \
-        ExReleaseSpinLock##mode(lock); \
-        KeLeaveCriticalRegion();       \
-    }
+static inline void
+_release_spin_lock(EX_SPIN_LOCK* lock, KIRQL oldIrql, bool exclusive)
+{
+    exclusive ? ExAcquireSpinLockExclusive(lock) : ExAcquireSpinLockShared(lock);
+    KeLeaveCriticalRegion();
+}
 
-#define ACQUIRE_SPIN_LOCK_EXCLUSIVE(lock) _ACQUIRE_SPIN_LOCK(lock, Exclusive)
-#define ACQUIRE_SPIN_LOCK_SHARED(lock) _ACQUIRE_SPIN_LOCK(lock, Shared)
+#define ACQUIRE_SPIN_LOCK_EXCLUSIVE(lock) _acquire_spin_lock_exclusive(lock, TRUE)
+#define ACQUIRE_SPIN_LOCK_SHARED(lock) _acquire_spin_lock_shared(lock, FALSE)
 
-#define RELEASE_SPIN_LOCK_EXCLUSIVE(lock) _RELEASE_SPIN_LOCK(lock, Exclusive)
-#define RELEASE_SPIN_LOCK_SHARED(lock) _RELEASE_SPIN_LOCK(lock, Shared)
+#define RELEASE_SPIN_LOCK_EXCLUSIVE(lock, oldIrql) _release_spin_lock_exclusive(lock, oldIrql, TRUE)
+#define RELEASE_SPIN_LOCK_SHARED(lock, oldIrql) _release_spin_lock_shared(lock, oldIrql, FALSE)
 
 /**
  * @brief Initialize the hook client rundown state.
@@ -255,7 +257,7 @@ ebpf_extension_hook_check_attach_parameter(
         using_wild_card_attach_parameter = TRUE;
     }
 
-    ACQUIRE_SPIN_LOCK_SHARED(&provider_context->lock);
+    KIRQL oldIrql = ACQUIRE_SPIN_LOCK_SHARED(&provider_context->lock);
     lock_held = TRUE;
     if (using_wild_card_attach_parameter) {
         // Client requested wild card attach parameter. This will only be allowed if there are no other clients
@@ -296,7 +298,7 @@ ebpf_extension_hook_check_attach_parameter(
 
 Exit:
     if (lock_held) {
-        RELEASE_SPIN_LOCK_SHARED(&provider_context->lock);
+        RELEASE_SPIN_LOCK_SHARED(&provider_context->lock, oldIrql);
     }
 
     EBPF_EXT_RETURN_RESULT(result);
@@ -395,9 +397,9 @@ _ebpf_extension_hook_provider_attach_client(
     result = local_provider_context->attach_callback(hook_client, local_provider_context);
 
     if (result == EBPF_SUCCESS) {
-        ACQUIRE_SPIN_LOCK_EXCLUSIVE(&local_provider_context->lock);
+        KIRQL oldIrql = ACQUIRE_SPIN_LOCK_EXCLUSIVE(&local_provider_context->lock);
         InsertTailList(&local_provider_context->attached_clients_list, &hook_client->link);
-        RELEASE_SPIN_LOCK_EXCLUSIVE(&local_provider_context->lock);
+        RELEASE_SPIN_LOCK_EXCLUSIVE(&local_provider_context->lock, oldIrql);
     } else {
         EBPF_EXT_LOG_MESSAGE_UINT32(
             EBPF_EXT_TRACELOG_LEVEL_ERROR,
@@ -449,9 +451,9 @@ _ebpf_extension_hook_provider_detach_client(_In_ const void* provider_binding_co
     // Invoke hook specific handler for processing client detach.
     local_provider_context->detach_callback(local_client_context);
 
-    ACQUIRE_SPIN_LOCK_EXCLUSIVE(&local_provider_context->lock);
+    KIRQL oldIrql = ACQUIRE_SPIN_LOCK_EXCLUSIVE(&local_provider_context->lock);
     RemoveEntryList(&local_client_context->link);
-    RELEASE_SPIN_LOCK_EXCLUSIVE(&local_provider_context->lock);
+    RELEASE_SPIN_LOCK_EXCLUSIVE(&local_provider_context->lock, oldIrql);
 
     IoQueueWorkItem(
         local_client_context->detach_work_item,
@@ -510,7 +512,7 @@ ebpf_extension_hook_provider_register(
         EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, local_provider_context, "local_provider_context", status);
 
     memset(local_provider_context, 0, sizeof(ebpf_extension_hook_provider_t));
-    ExInitializePushLock(&local_provider_context->lock);
+    ExInitializeSpinLock(&local_provider_context->lock);
     InitializeListHead(&local_provider_context->attached_clients_list);
 
     characteristics = &local_provider_context->characteristics;
@@ -551,12 +553,12 @@ ebpf_extension_hook_client_t*
 ebpf_extension_hook_get_attached_client(_Inout_ ebpf_extension_hook_provider_t* provider_context)
 {
     ebpf_extension_hook_client_t* client_context = NULL;
-    ACQUIRE_SPIN_LOCK_SHARED(&provider_context->lock);
+    KIRQL oldIrql = ACQUIRE_SPIN_LOCK_SHARED(&provider_context->lock);
     if (!IsListEmpty(&provider_context->attached_clients_list)) {
         client_context = (ebpf_extension_hook_client_t*)CONTAINING_RECORD(
             provider_context->attached_clients_list.Flink, ebpf_extension_hook_client_t, link);
     }
-    RELEASE_SPIN_LOCK_SHARED(&provider_context->lock);
+    RELEASE_SPIN_LOCK_SHARED(&provider_context->lock, oldIrql);
     return client_context;
 }
 
@@ -566,7 +568,7 @@ ebpf_extension_hook_get_next_attached_client(
     _In_opt_ const ebpf_extension_hook_client_t* client_context)
 {
     ebpf_extension_hook_client_t* next_client = NULL;
-    ACQUIRE_SPIN_LOCK_SHARED(&provider_context->lock);
+    KIRQL oldIrql = ACQUIRE_SPIN_LOCK_SHARED(&provider_context->lock);
     if (client_context == NULL) {
         // Return the first attached client (if any).
         if (!IsListEmpty(&provider_context->attached_clients_list)) {
@@ -580,6 +582,6 @@ ebpf_extension_hook_get_next_attached_client(
                 client_context->link.Flink, ebpf_extension_hook_client_t, link);
         }
     }
-    RELEASE_SPIN_LOCK_SHARED(&provider_context->lock);
+    RELEASE_SPIN_LOCK_SHARED(&provider_context->lock, oldIrql);
     return next_client;
 }

--- a/libs/ebpf_ext/ebpf_ext_hook_provider.c
+++ b/libs/ebpf_ext/ebpf_ext_hook_provider.c
@@ -52,24 +52,6 @@ typedef struct _ebpf_extension_hook_provider
         LIST_ENTRY attached_clients_list; ///< Linked list of hook NPI clients that are attached to this provider.
 } ebpf_extension_hook_provider_t;
 
-#define _ACQUIRE_PUSH_LOCK(lock, mode) \
-    {                                  \
-        KeEnterCriticalRegion();       \
-        ExAcquirePushLock##mode(lock); \
-    }
-
-#define _RELEASE_PUSH_LOCK(lock, mode) \
-    {                                  \
-        ExReleasePushLock##mode(lock); \
-        KeLeaveCriticalRegion();       \
-    }
-
-#define ACQUIRE_PUSH_LOCK_EXCLUSIVE(lock) _ACQUIRE_PUSH_LOCK(lock, Exclusive)
-#define ACQUIRE_PUSH_LOCK_SHARED(lock) _ACQUIRE_PUSH_LOCK(lock, Shared)
-
-#define RELEASE_PUSH_LOCK_EXCLUSIVE(lock) _RELEASE_PUSH_LOCK(lock, Exclusive)
-#define RELEASE_PUSH_LOCK_SHARED(lock) _RELEASE_PUSH_LOCK(lock, Shared)
-
 /**
  * @brief Initialize the hook client rundown state.
  *

--- a/tests/neteventebpfext/netevent_sim/netevent_npi_client.h
+++ b/tests/neteventebpfext/netevent_sim/netevent_npi_client.h
@@ -17,9 +17,9 @@ typedef void (*netevent_push_event)(netevent_event_info_t*);
 typedef enum _netevent_capture_type
 {
     NeteventCapture_All = 1,
-    NetevenCapture_Flow,
-    NetevenCapture_Drop,
-    NetevenCapture_None
+    NeteventCapture_Flow,
+    NeteventCapture_Drop,
+    NeteventCapture_None
 } netevent_capture_type_t;
 
 typedef struct netevent_ext_header

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.c
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.c
@@ -17,7 +17,7 @@
 #define EVENT_INTERVAL_KEY_PATH L"\\Registry\\Machine\\Software\\eBPF\\Parameters"
 #define EVENT_INTERVAL_VALUE_NAME L"NetEventInterval"
 #define DEFAULT_EVENT_INTERVAL 1U // milliseconds
-#define DISPATCH_ITQL_EVENT_INTERVAL 5
+#define DISPATCH_IRQL_EVENT_INTERVAL 2U
 
 DRIVER_INITIALIZE DriverEntry;
 DRIVER_UNLOAD DriverUnload;
@@ -118,7 +118,7 @@ timer_dpc_routine(
         netevent_push_event push_event_helper =
             (netevent_push_event)(_netevent_provider_binding_context.client_dispatch->helper_function_address[0]);
 
-        if (counter % DISPATCH_ITQL_EVENT_INTERVAL == 0) {
+        if ((counter % DISPATCH_IRQL_EVENT_INTERVAL) == 0) {
             KIRQL old_irql;
             KeRaiseIrql(DISPATCH_LEVEL, &old_irql);
             push_event_helper(&event_payload);

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.c
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.c
@@ -103,7 +103,7 @@ timer_dpc_routine(
             .reason = DROP_REASON_NONE,
             .event_counter = counter};
 
-        if (_netevent_provider_binding_context.client_dispatch->capture_type == NetevenCapture_Drop) {
+        if (_netevent_provider_binding_context.client_dispatch->capture_type == NeteventCapture_Drop) {
             demo_event.header.event_type = NOTIFY_EVENT_TYPE_NETEVENT_DROP;
             demo_event.reason = DROP_REASON_SECURITY_POLICY;
         }

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -231,7 +231,7 @@ TEST_CASE("netevent_attach_opt_simulation", "[neteventebpfext]")
 
     // Test reattach with different capture type
     event_count_before = event_count;
-    attach_opts.capture_type = NetevenCapture_Drop;
+    attach_opts.capture_type = NeteventCapture_Drop;
     result = ebpf_program_attach(
         netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts), &netevent_monitor_link);
     REQUIRE(result == EBPF_SUCCESS);


### PR DESCRIPTION
## Description

- Changing all push locks to spin locks on the code path that invokes netevent programs so that they can be invoked at dispatch IRQL. Closes #200 
- Put clang path under quotes to fix build issues due to spaces in clang path.

## Testing

For testing the netevent ext , netevent_sim driver invokes the program in a DPC. DPC runs at Dispatch IRQL. Modified netevent_sim to invoke program in a ThreadedDPC which runs at passive IRQL by default. Also raised IRQL to dispatch periodically to ensure invocation is tested at both IRQLs. 

## Documentation

NA

## Installation

NA
