### PR TITLE
Modify netevent ctx

### DIFF
--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -449,7 +449,13 @@ _ebpf_netevent_program_context_create(
     memcpy(&netevent_event_context->netevent_event_md, context_in, sizeof(netevent_event_md_t));
 
     // Copy the event's pointer & size from the caller, to the out context.
-    netevent_event_context->netevent_event_md.data = (uint8_t*)data_in;
+    if (data_size_in > NETEVENT_HEADER_LENGTH) {
+        netevent_event_context->netevent_event_md.data_meta = (uint8_t*)data_in;
+        netevent_event_context->netevent_event_md.data = (uint8_t*)data_in + NETEVENT_HEADER_LENGTH;
+    } else {
+        netevent_event_context->netevent_event_md.data = (uint8_t*)data_in;
+        netevent_event_context->netevent_event_md.data_meta = netevent_event_context->netevent_event_md.data;
+    }
     netevent_event_context->netevent_event_md.data_end = (uint8_t*)data_in + data_size_in;
     *context = &netevent_event_context->netevent_event_md;
     netevent_event_context = NULL;
@@ -487,6 +493,7 @@ _ebpf_netevent_program_context_destroy(
         memcpy(netevent_event_context_out, &netevent_event_context->netevent_event_md, sizeof(netevent_event_md_t));
 
         // Zero out the event context info.
+        netevent_event_context_out->data_meta = 0;
         netevent_event_context_out->data = 0;
         netevent_event_context_out->data_end = 0;
         *context_size_out = sizeof(netevent_event_md_t);
@@ -496,13 +503,13 @@ _ebpf_netevent_program_context_destroy(
 
     // Copy the event data to 'data_out'.
     if (data_out != NULL && *data_size_out >= (size_t)(netevent_event_context->netevent_event_md.data_end -
-                                                       netevent_event_context->netevent_event_md.data)) {
+                                                       netevent_event_context->netevent_event_md.data_meta)) {
         memcpy(
             data_out,
-            netevent_event_context->netevent_event_md.data,
-            netevent_event_context->netevent_event_md.data_end - netevent_event_context->netevent_event_md.data);
+            netevent_event_context->netevent_event_md.data_meta,
+            netevent_event_context->netevent_event_md.data_end - netevent_event_context->netevent_event_md.data_meta);
         *data_size_out =
-            netevent_event_context->netevent_event_md.data_end - netevent_event_context->netevent_event_md.data;
+            netevent_event_context->netevent_event_md.data_end - netevent_event_context->netevent_event_md.data_meta;
     } else {
         *data_size_out = 0;
     }
@@ -559,11 +566,11 @@ _ebpf_netevent_push_event(_In_ netevent_event_t* netevent_event)
         _event_buffer_data_start = _event_buffer + NETEVENT_HEADER_LENGTH;
         memcpy(_event_buffer, netevent_event->event_start, NETEVENT_HEADER_LENGTH);
         memcpy(_event_buffer_data_start, data_start, payload_size - NETEVENT_HEADER_LENGTH);
-        netevent_event_notify_context.netevent_event_md.data_meta = _event_buffer;
     } else {
         _event_buffer_data_start = _event_buffer;
         memcpy(_event_buffer, netevent_event->event_start, payload_size);
     }
+    netevent_event_notify_context.netevent_event_md.data_meta = _event_buffer;
     netevent_event_notify_context.netevent_event_md.data = _event_buffer_data_start;
     netevent_event_notify_context.netevent_event_md.data_end = _event_buffer + payload_size;
 

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -7,7 +7,6 @@
  */
 
 #include "ebpf_netevent_hooks.h"
-#include "framework.h"
 #include "netevent_ebpf_ext_event.h"
 #include "netevent_ebpf_ext_program_info.h"
 typedef struct _EX_RUNDOWN_REF_CACHE_AWARE* PEX_RUNDOWN_REF_CACHE_AWARE;
@@ -527,8 +526,8 @@ _ebpf_netevent_push_event(_In_ netevent_event_t* netevent_event)
     bool spin_lock_acquired = false;
 
     PKTMON_EVT_STREAM_PACKET_HEADER* packetHeader = netevent_event->BufferStart;
-    // NOTE: For backwards compatibility, do not rely on sizeof(PKTMON_EVT_STREAM_METADATA), as in the future
-    // PKTMON_EVT_STREAM_METADATA might be expanded. Use PacketMetaDataLength instead to skip over the metadata.
+    // Using PacketMetaDataLength instead of sizeof(PKTMON_EVT_STREAM_METADATA) for backward compatibility
+    // since  PKTMON_EVT_STREAM_METADATA can be expanded in the future.
     uint8_t* payload_start = (uint8_t*)(&packetHeader->Metadata);
     payload_start += packetHeader->PacketDescriptor.PacketMetaDataLength;
     uint64_t payload_size = netevent_event->BufferEnd - payload_start;

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -449,7 +449,7 @@ _ebpf_netevent_program_context_create(
     memcpy(&netevent_event_context->netevent_event_md, context_in, sizeof(netevent_event_md_t));
 
     // Copy the event's pointer & size from the caller, to the out context.
-    netevent_event_context->netevent_event_md.data_start = (uint8_t*)data_in;
+    netevent_event_context->netevent_event_md.data = (uint8_t*)data_in;
     netevent_event_context->netevent_event_md.data_end = (uint8_t*)data_in + data_size_in;
     *context = &netevent_event_context->netevent_event_md;
     netevent_event_context = NULL;
@@ -487,7 +487,7 @@ _ebpf_netevent_program_context_destroy(
         memcpy(netevent_event_context_out, &netevent_event_context->netevent_event_md, sizeof(netevent_event_md_t));
 
         // Zero out the event context info.
-        netevent_event_context_out->data_start = 0;
+        netevent_event_context_out->data = 0;
         netevent_event_context_out->data_end = 0;
         *context_size_out = sizeof(netevent_event_md_t);
     } else {
@@ -496,13 +496,13 @@ _ebpf_netevent_program_context_destroy(
 
     // Copy the event data to 'data_out'.
     if (data_out != NULL && *data_size_out >= (size_t)(netevent_event_context->netevent_event_md.data_end -
-                                                       netevent_event_context->netevent_event_md.data_start)) {
+                                                       netevent_event_context->netevent_event_md.data)) {
         memcpy(
             data_out,
-            netevent_event_context->netevent_event_md.data_start,
-            netevent_event_context->netevent_event_md.data_end - netevent_event_context->netevent_event_md.data_start);
+            netevent_event_context->netevent_event_md.data,
+            netevent_event_context->netevent_event_md.data_end - netevent_event_context->netevent_event_md.data);
         *data_size_out =
-            netevent_event_context->netevent_event_md.data_end - netevent_event_context->netevent_event_md.data_start;
+            netevent_event_context->netevent_event_md.data_end - netevent_event_context->netevent_event_md.data;
     } else {
         *data_size_out = 0;
     }
@@ -564,7 +564,7 @@ _ebpf_netevent_push_event(_In_ netevent_event_t* netevent_event)
         _event_buffer_data_start = _event_buffer;
         memcpy(_event_buffer, netevent_event->event_start, payload_size);
     }
-    netevent_event_notify_context.netevent_event_md.data_start = _event_buffer_data_start;
+    netevent_event_notify_context.netevent_event_md.data = _event_buffer_data_start;
     netevent_event_notify_context.netevent_event_md.data_end = _event_buffer + payload_size;
 
     // For each attached client call the netevent hook.

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -554,8 +554,12 @@ _ebpf_netevent_push_event(_In_ netevent_event_t* netevent_event)
         _event_buffer = new_event_buffer;
         _event_buffer_size = payload_size;
     }
-    netevent_event_notify_context.netevent_event_md.header.event_id = packetHeader->EventId;
-    netevent_event_notify_context.netevent_event_md.header.metadata.drop_reason = packetHeader->Metadata.DropReason;
+
+    C_ASSERT(sizeof(netevent_event_notify_context.netevent_event_md.header) == sizeof(PKTMON_EVT_STREAM_PACKET_HEADER));
+    memcpy(
+        &netevent_event_notify_context.netevent_event_md.header,
+        packetHeader,
+        sizeof(netevent_event_notify_context.netevent_event_md.header));
 
     memcpy(_event_buffer, payload_start, payload_size);
     netevent_event_notify_context.netevent_event_md.payload_start = _event_buffer;

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -7,10 +7,12 @@
  */
 
 #include "ebpf_netevent_hooks.h"
+#include "framework.h"
 #include "netevent_ebpf_ext_event.h"
 #include "netevent_ebpf_ext_program_info.h"
-
+typedef struct _EX_RUNDOWN_REF_CACHE_AWARE* PEX_RUNDOWN_REF_CACHE_AWARE;
 #include <errno.h>
+#include <pktmonnpik.h>
 
 //
 // Global variables.
@@ -553,7 +555,9 @@ _ebpf_netevent_push_event(_In_ netevent_event_t* netevent_event)
         _event_buffer = new_event_buffer;
         _event_buffer_size = payload_size;
     }
-    netevent_event_notify_context.netevent_event_md.header = *packetHeader;
+    netevent_event_notify_context.netevent_event_md.header.event_id = packetHeader->EventId;
+    netevent_event_notify_context.netevent_event_md.header.metadata.drop_reason = packetHeader->Metadata.DropReason;
+
     memcpy(_event_buffer, payload_start, payload_size);
     netevent_event_notify_context.netevent_event_md.payload_start = _event_buffer;
     netevent_event_notify_context.netevent_event_md.payload_end = _event_buffer + payload_size;

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -559,7 +559,9 @@ _ebpf_netevent_push_event(_In_ netevent_event_t* netevent_event)
 
     // C_ASSERT(sizeof(netevent_event_notify_context.netevent_event_md.header) ==
     // sizeof(PKTMON_EVT_STREAM_PACKET_HEADER));
-    memcpy(_event_buffer, packetHeader, sizeof(PKTMON_EVT_STREAM_PACKET_HEADER));
+    if (sizeof(PKTMON_EVT_STREAM_PACKET_HEADER) < payload_size) {
+        memcpy(_event_buffer, packetHeader, sizeof(PKTMON_EVT_STREAM_PACKET_HEADER));
+    }
     memcpy(_event_buffer_data_start, data_start, payload_size - sizeof(PKTMON_EVT_STREAM_PACKET_HEADER));
 
     netevent_event_notify_context.netevent_event_md.data_meta = _event_buffer;

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
@@ -22,8 +22,8 @@ static const ebpf_helper_function_prototype_t _netevent_event_ebpf_extension_hel
 
 static const ebpf_context_descriptor_t _ebpf_netevent_program_context_descriptor = {
     (int)sizeof(netevent_event_md_t),
-    EBPF_OFFSET_OF(netevent_event_md_t, event_data_start),
-    EBPF_OFFSET_OF(netevent_event_md_t, event_data_end),
+    EBPF_OFFSET_OF(netevent_event_md_t, payload_start),
+    EBPF_OFFSET_OF(netevent_event_md_t, payload_end),
     -1,
 };
 

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
@@ -24,7 +24,7 @@ static const ebpf_context_descriptor_t _ebpf_netevent_program_context_descriptor
     (int)sizeof(netevent_event_md_t),
     EBPF_OFFSET_OF(netevent_event_md_t, data_start),
     EBPF_OFFSET_OF(netevent_event_md_t, data_end),
-    -1,
+    EBPF_OFFSET_OF(netevent_event_md_t, data_meta),
 };
 
 static const ebpf_program_type_descriptor_t _ebpf_program_type_netevent_guid = {

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
@@ -22,8 +22,8 @@ static const ebpf_helper_function_prototype_t _netevent_event_ebpf_extension_hel
 
 static const ebpf_context_descriptor_t _ebpf_netevent_program_context_descriptor = {
     (int)sizeof(netevent_event_md_t),
-    EBPF_OFFSET_OF(netevent_event_md_t, payload_start),
-    EBPF_OFFSET_OF(netevent_event_md_t, payload_end),
+    EBPF_OFFSET_OF(netevent_event_md_t, data_start),
+    EBPF_OFFSET_OF(netevent_event_md_t, data_end),
     -1,
 };
 

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
@@ -22,7 +22,7 @@ static const ebpf_helper_function_prototype_t _netevent_event_ebpf_extension_hel
 
 static const ebpf_context_descriptor_t _ebpf_netevent_program_context_descriptor = {
     (int)sizeof(netevent_event_md_t),
-    EBPF_OFFSET_OF(netevent_event_md_t, data_start),
+    EBPF_OFFSET_OF(netevent_event_md_t, data),
     EBPF_OFFSET_OF(netevent_event_md_t, data_end),
     EBPF_OFFSET_OF(netevent_event_md_t, data_meta),
 };

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -308,8 +308,9 @@ _ebpf_process_context_destroy(
     }
 
     // Copy the command to the data_out.
-    if (data_out != NULL && *data_size_out >= (size_t)(process_context->process_md.command_end -
-                                                       process_context->process_md.command_start)) {
+    if (data_out != NULL &&
+        *data_size_out >=
+            (size_t)(process_context->process_md.command_end - process_context->process_md.command_start)) {
         memcpy(
             data_out,
             process_context->process_md.command_start,

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -308,9 +308,8 @@ _ebpf_process_context_destroy(
     }
 
     // Copy the command to the data_out.
-    if (data_out != NULL &&
-        *data_size_out >=
-            (size_t)(process_context->process_md.command_end - process_context->process_md.command_start)) {
+    if (data_out != NULL && *data_size_out >= (size_t)(process_context->process_md.command_end -
+                                                       process_context->process_md.command_start)) {
         memcpy(
             data_out,
             process_context->process_md.command_start,

--- a/include/ebpf_netevent_hooks.h
+++ b/include/ebpf_netevent_hooks.h
@@ -1,20 +1,55 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 #pragma once
-#include "framework.h"
-
 #include <stddef.h>
 #include <stdint.h>
-typedef struct _EX_RUNDOWN_REF_CACHE_AWARE* PEX_RUNDOWN_REF_CACHE_AWARE;
-#include <pktmonnpik.h>
 
 // This file contains APIs for hooks and helpers that are
 // exposed by neteventebpfext.sys for use by eBPF programs.
 
+//
+// Packet descriptor used for event streaming
+//
+typedef struct _netevent_packet_descriptor
+{
+    uint32_t packet_original_length;
+    uint32_t packet_logged_length;
+    uint32_t packet_metadata_length;
+} netevent_packet_descriptor_t;
+
+//
+// Metadata information used for event streaming
+//
+typedef struct _netevent_metadata
+{
+    uint64_t pkt_group_id;
+    uint16_t pkt_count;
+    uint16_t appearance_count;
+    uint16_t direction_name;
+    uint16_t packet_type;
+    uint16_t component_id;
+    uint16_t edge_id;
+    uint16_t filter_id;
+    uint32_t drop_reason;
+    uint32_t drop_location;
+    uint16_t proc_num;
+    uint64_t timestamp;
+} netevent_metadata_t;
+
+//
+// Packet header used for event streaming
+//
+typedef struct _netevent_packet_header
+{
+    uint8_t event_id;
+    netevent_packet_descriptor_t packet_descriptor;
+    netevent_metadata_t metadata;
+} netevent_packet_header_t;
+
 //// This structure is used to pass event data to the eBPF program.
 typedef struct _netevent_event_md
 {
-    PKTMON_EVT_STREAM_PACKET_HEADER header;
+    netevent_packet_header_t header;
     uint8_t* payload_start;
     uint8_t* payload_end;
 } netevent_event_md_t;

--- a/include/ebpf_netevent_hooks.h
+++ b/include/ebpf_netevent_hooks.h
@@ -12,9 +12,11 @@
 // Packet descriptor used for event streaming.
 typedef struct _netevent_packet_descriptor
 {
-    uint32_t packet_original_length;
-    uint32_t packet_logged_length;
-    uint32_t packet_metadata_length;
+    uint32_t packet_original_length; // Original length of the packet.
+    uint32_t packet_logged_length;   // The original packet might have been truncated during logging. This field
+                                     // represents the size of the received packet pointed to by `data_start`.
+    uint32_t packet_metadata_length; // Length of the packet metadata. Can be greater that sizeof(packet_metadata_t) if
+                                     // metadata fields are added in the future.
 } netevent_packet_descriptor_t;
 
 // Metadata information used for event streaming.
@@ -48,8 +50,8 @@ typedef struct _netevent_packet_header
 typedef struct _netevent_event_md
 {
     netevent_packet_header_t header;
-    uint8_t* payload_start;
-    uint8_t* payload_end;
+    uint8_t* data_start;
+    uint8_t* data_end;
 } netevent_event_md_t;
 
 // Packet capture type.

--- a/include/ebpf_netevent_hooks.h
+++ b/include/ebpf_netevent_hooks.h
@@ -7,9 +7,7 @@
 // This file contains APIs for hooks and helpers that are
 // exposed by neteventebpfext.sys for use by eBPF programs.
 
-//
-// Packet descriptor used for event streaming
-//
+// Packet descriptor used for event streaming.
 typedef struct _netevent_packet_descriptor
 {
     uint32_t packet_original_length;
@@ -17,9 +15,7 @@ typedef struct _netevent_packet_descriptor
     uint32_t packet_metadata_length;
 } netevent_packet_descriptor_t;
 
-//
-// Metadata information used for event streaming
-//
+// Metadata information used for event streaming.
 typedef struct _netevent_metadata
 {
     uint64_t pkt_group_id;
@@ -36,9 +32,7 @@ typedef struct _netevent_metadata
     uint64_t timestamp;
 } netevent_metadata_t;
 
-//
-// Packet header used for event streaming
-//
+// Packet header used for event streaming.
 typedef struct _netevent_packet_header
 {
     uint8_t event_id;
@@ -46,7 +40,7 @@ typedef struct _netevent_packet_header
     netevent_metadata_t metadata;
 } netevent_packet_header_t;
 
-//// This structure is used to pass event data to the eBPF program.
+// This structure is used to pass event data to the eBPF program.
 typedef struct _netevent_event_md
 {
     netevent_packet_header_t header;
@@ -54,9 +48,7 @@ typedef struct _netevent_event_md
     uint8_t* payload_end;
 } netevent_event_md_t;
 
-//
-// Packet capture type
-//
+// Packet capture type.
 typedef enum _netevent_capture_type
 {
     NeteventCapture_All = 1,

--- a/include/ebpf_netevent_hooks.h
+++ b/include/ebpf_netevent_hooks.h
@@ -7,45 +7,6 @@
 // This file contains APIs for hooks and helpers that are
 // exposed by neteventebpfext.sys for use by eBPF programs.
 
-#pragma pack(push, 1)
-
-// Packet descriptor used for event streaming.
-typedef struct _netevent_packet_descriptor
-{
-    uint32_t packet_original_length; // Original length of the packet.
-    uint32_t packet_logged_length;   // The original packet might have been truncated during logging. This field
-                                     // represents the size of the received packet pointed to by `data_start`.
-    uint32_t packet_metadata_length; // Length of the packet metadata. Can be greater that sizeof(packet_metadata_t) if
-                                     // metadata fields are added in the future.
-} netevent_packet_descriptor_t;
-
-// Metadata information used for event streaming.
-typedef struct _netevent_metadata
-{
-    uint64_t pkt_group_id;
-    uint16_t pkt_count;
-    uint16_t appearance_count;
-    uint16_t direction_name;
-    uint16_t packet_type;
-    uint16_t component_id;
-    uint16_t edge_id;
-    uint16_t filter_id;
-    uint32_t drop_reason;
-    uint32_t drop_location;
-    uint16_t proc_num;
-    uint64_t timestamp;
-} netevent_metadata_t;
-
-// Packet header used for event streaming.
-typedef struct _netevent_packet_header
-{
-    uint8_t event_id;
-    netevent_packet_descriptor_t packet_descriptor;
-    netevent_metadata_t metadata;
-} netevent_packet_header_t;
-
-#pragma pack(pop)
-
 // This structure is used to pass event data to the eBPF program.
 typedef struct _netevent_event_md
 {

--- a/include/ebpf_netevent_hooks.h
+++ b/include/ebpf_netevent_hooks.h
@@ -49,7 +49,7 @@ typedef struct _netevent_packet_header
 // This structure is used to pass event data to the eBPF program.
 typedef struct _netevent_event_md
 {
-    netevent_packet_header_t header;
+    uint8_t* data_meta;
     uint8_t* data_start;
     uint8_t* data_end;
 } netevent_event_md_t;

--- a/include/ebpf_netevent_hooks.h
+++ b/include/ebpf_netevent_hooks.h
@@ -7,6 +7,8 @@
 // This file contains APIs for hooks and helpers that are
 // exposed by neteventebpfext.sys for use by eBPF programs.
 
+#pragma pack(push, 1)
+
 // Packet descriptor used for event streaming.
 typedef struct _netevent_packet_descriptor
 {
@@ -39,6 +41,8 @@ typedef struct _netevent_packet_header
     netevent_packet_descriptor_t packet_descriptor;
     netevent_metadata_t metadata;
 } netevent_packet_header_t;
+
+#pragma pack(pop)
 
 // This structure is used to pass event data to the eBPF program.
 typedef struct _netevent_event_md

--- a/include/ebpf_netevent_hooks.h
+++ b/include/ebpf_netevent_hooks.h
@@ -11,7 +11,7 @@
 typedef struct _netevent_event_md
 {
     uint8_t* data_meta;
-    uint8_t* data_start;
+    uint8_t* data;
     uint8_t* data_end;
 } netevent_event_md_t;
 

--- a/include/ebpf_netevent_hooks.h
+++ b/include/ebpf_netevent_hooks.h
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 #pragma once
+#include "framework.h"
+
 #include <stddef.h>
 #include <stdint.h>
+typedef struct _EX_RUNDOWN_REF_CACHE_AWARE* PEX_RUNDOWN_REF_CACHE_AWARE;
+#include <pktmonnpik.h>
 
 // This file contains APIs for hooks and helpers that are
 // exposed by neteventebpfext.sys for use by eBPF programs.
@@ -10,9 +14,9 @@
 //// This structure is used to pass event data to the eBPF program.
 typedef struct _netevent_event_md
 {
-    uint8_t* event_data_start; ///< Pointer to start of the data associated with the event.
-    uint8_t* event_data_end;   ///< Pointer to end of the data associated with the event.
-
+    PKTMON_EVT_STREAM_PACKET_HEADER header;
+    uint8_t* payload_start;
+    uint8_t* payload_end;
 } netevent_event_md_t;
 
 //

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -8,4 +8,12 @@
   <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2454" targetFramework="native" />
   <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2454" targetFramework="native" />
   <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2161" targetFramework="native" />
+  <!-- user -->
 </packages>

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="eBPF-for-Windows" version="0.18.0" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2454" targetFramework="native" />
 </packages>

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -15,5 +15,4 @@
   <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2161" targetFramework="native" />
   <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2161" targetFramework="native" />
   <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2161" targetFramework="native" />
-  <!-- user -->
 </packages>

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.c
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.c
@@ -96,7 +96,7 @@ timer_dpc_routine(
         // Create a test event
         LONG counter = InterlockedIncrement(&_event_counter);
         netevent_message_t demo_event = {
-            .header = {.EventId = NOTIFY_EVENT_TYPE_NETEVENT_LOG},
+            .header = {.event_id = NOTIFY_EVENT_TYPE_NETEVENT_LOG},
             .payload = {
                 .source_ip = {192, 168, 1, 1},
                 .destination_ip = {10, 11, 12, 1},
@@ -105,8 +105,8 @@ timer_dpc_routine(
                 .event_counter = counter}};
 
         if (_netevent_provider_binding_context.client_dispatch->capture_type == NeteventCapture_Drop) {
-            demo_event.header.event_type = NOTIFY_EVENT_TYPE_NETEVENT_DROP;
-            demo_event.reason = DROP_REASON_SECURITY_POLICY;
+            demo_event.header.event_id = NOTIFY_EVENT_TYPE_NETEVENT_DROP;
+            demo_event.header.metadata.drop_reason = DROP_REASON_SECURITY_POLICY;
         }
 
         // Create the event payload

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.c
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.c
@@ -96,13 +96,13 @@ timer_dpc_routine(
         // Create a test event
         LONG counter = InterlockedIncrement(&_event_counter);
         netevent_message_t demo_event = {
-            .header = {.event_type = NOTIFY_EVENT_TYPE_NETEVENT_LOG},
-            .source_ip = {192, 168, 1, 1},
-            .destination_ip = {10, 11, 12, 1},
-            .source_port = 12345,
-            .destination_port = 80,
-            .reason = DROP_REASON_NONE,
-            .event_counter = counter};
+            .header = {.EventId = NOTIFY_EVENT_TYPE_NETEVENT_LOG},
+            .payload = {
+                .source_ip = {192, 168, 1, 1},
+                .destination_ip = {10, 11, 12, 1},
+                .source_port = 12345,
+                .destination_port = 80,
+                .event_counter = counter}};
 
         if (_netevent_provider_binding_context.client_dispatch->capture_type == NeteventCapture_Drop) {
             demo_event.header.event_type = NOTIFY_EVENT_TYPE_NETEVENT_DROP;

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.c
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.c
@@ -96,7 +96,9 @@ timer_dpc_routine(
         // Create a test event
         LONG counter = InterlockedIncrement(&_event_counter);
         netevent_message_t demo_event = {
-            .header = {.event_id = NOTIFY_EVENT_TYPE_NETEVENT_LOG},
+            .header =
+                {.event_id = NOTIFY_EVENT_TYPE_NETEVENT_LOG,
+                 .packet_descriptor = {.packet_metadata_length = sizeof(netevent_message_metadata_t)}},
             .payload = {
                 .source_ip = {192, 168, 1, 1},
                 .destination_ip = {10, 11, 12, 1},

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.c
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.c
@@ -100,6 +100,7 @@ timer_dpc_routine(
                 {.event_id = NOTIFY_EVENT_TYPE_NETEVENT_LOG,
                  .packet_descriptor = {.packet_metadata_length = sizeof(netevent_message_metadata_t)}},
             .payload = {
+                .event_id = NOTIFY_EVENT_TYPE_NETEVENT_LOG,
                 .source_ip = {192, 168, 1, 1},
                 .destination_ip = {10, 11, 12, 1},
                 .source_port = 12345,
@@ -109,6 +110,7 @@ timer_dpc_routine(
         if (_netevent_provider_binding_context.client_dispatch->capture_type == NeteventCapture_Drop) {
             demo_event.header.event_id = NOTIFY_EVENT_TYPE_NETEVENT_DROP;
             demo_event.header.metadata.drop_reason = DROP_REASON_SECURITY_POLICY;
+            demo_event.payload.event_id = NOTIFY_EVENT_TYPE_NETEVENT_DROP;
         }
 
         // Create the event payload

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.c
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.c
@@ -97,8 +97,8 @@ timer_dpc_routine(
         LONG counter = InterlockedIncrement(&_event_counter);
         netevent_message_t demo_event = {
             .header =
-                {.event_id = NOTIFY_EVENT_TYPE_NETEVENT_LOG,
-                 .packet_descriptor = {.packet_metadata_length = sizeof(netevent_message_metadata_t)}},
+                {.EventId = NOTIFY_EVENT_TYPE_NETEVENT_LOG,
+                 .PacketDescriptor = {.PacketMetaDataLength = sizeof(PKTMON_EVT_STREAM_METADATA)}},
             .payload = {
                 .event_id = NOTIFY_EVENT_TYPE_NETEVENT_LOG,
                 .source_ip = {192, 168, 1, 1},
@@ -108,8 +108,8 @@ timer_dpc_routine(
                 .event_counter = counter}};
 
         if (_netevent_provider_binding_context.client_dispatch->capture_type == NeteventCapture_Drop) {
-            demo_event.header.event_id = NOTIFY_EVENT_TYPE_NETEVENT_DROP;
-            demo_event.header.metadata.drop_reason = DROP_REASON_SECURITY_POLICY;
+            demo_event.header.EventId = NOTIFY_EVENT_TYPE_NETEVENT_DROP;
+            demo_event.header.Metadata.DropReason = DROP_REASON_SECURITY_POLICY;
             demo_event.payload.event_id = NOTIFY_EVENT_TYPE_NETEVENT_DROP;
         }
 

--- a/tests/neteventebpfext/netevent_sim/netevent_types.h
+++ b/tests/neteventebpfext/netevent_sim/netevent_types.h
@@ -38,7 +38,7 @@ typedef enum _drop_reason
 } drop_reason;
 typedef struct _netevent_payload
 {
-
+    unsigned char event_id;
     ip_address_t source_ip;
     ip_address_t destination_ip;
     unsigned short source_port;

--- a/tests/neteventebpfext/netevent_sim/netevent_types.h
+++ b/tests/neteventebpfext/netevent_sim/netevent_types.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+// #include <ntdef.h>
+// typedef struct _EX_RUNDOWN_REF_CACHE_AWARE* PEX_RUNDOWN_REF_CACHE_AWARE;
+// #include <pktmonnpik.h>
+
+// #include "..\..\..\include\ebpf_netevent_hooks.h"
 //
 // Define some demo event types
 //
@@ -46,45 +51,48 @@ typedef struct _netevent_payload
 //
 // Packet descriptor used for event streaming
 //
-typedef struct _netevent_packet_descriptor
+typedef struct _netevent_message_descriptor
 {
-    unsigned int PacketOriginalLength;
-    unsigned int PacketLoggedLength;
-    unsigned int PacketMetaDataLength;
-} netevent_packet_descriptor_t;
+    unsigned int packet_original_length;
+    unsigned int packet_logged_length;
+    unsigned int packet_metadata_length;
+} netevent_message_descriptor_t;
 
 //
 // Metadata information used for event streaming
 //
-typedef struct _netevent_stream_metadata
+typedef struct _netevent_message_metadata
 {
-    unsigned long long PktGroupId;
-    unsigned short PktCount;
-    unsigned short AppearanceCount;
-    unsigned short DirectionName;
-    unsigned short PacketType;
-    unsigned short ComponentId;
-    unsigned short EdgeId;
-    unsigned short FilterId;
-    unsigned int DropReason;
-    unsigned int DropLocation;
-    unsigned short ProcNum;
-    long TimeStamp;
-} netevent_stream_metadata_t;
+    unsigned long long pkt_group_id;
+    unsigned short pkt_count;
+    unsigned short appearance_count;
+    unsigned short direction_name;
+    unsigned short packet_type;
+    unsigned short component_id;
+    unsigned short edge_id;
+    unsigned short filter_id;
+    unsigned int drop_reason;
+    unsigned int drop_location;
+    unsigned short proc_num;
+    unsigned long long timestamp;
+} netevent_message_metadata_t;
 
 //
 // Packet header used for event streaming
 //
-typedef struct _netevent_stream_packet_header
+typedef struct _netevent_message_header
 {
-    unsigned char EventId;
-    netevent_packet_descriptor_t PacketDescriptor;
-    netevent_stream_metadata_t Metadata;
-} netevent_stream_packet_header_t;
+    unsigned char event_id;
+    netevent_message_descriptor_t packet_descriptor;
+    netevent_message_metadata_t metadata;
+} netevent_message_header_t;
 
-typedef struct _netevent_messsage
+//
+// This structure is used to pass event data to the eBPF program.
+//
+typedef struct _netevent_message
 {
-    netevent_stream_packet_header_t header;
+    netevent_message_header_t header;
     netevent_payload_t payload;
 } netevent_message_t;
 

--- a/tests/neteventebpfext/netevent_sim/netevent_types.h
+++ b/tests/neteventebpfext/netevent_sim/netevent_types.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+typedef struct _EX_RUNDOWN_REF_CACHE_AWARE* PEX_RUNDOWN_REF_CACHE_AWARE;
+#include <pktmonnpik.h>
+
 //
 // Define some demo event types
 //
@@ -43,43 +46,10 @@ typedef struct _netevent_payload
     unsigned long event_counter;
 } netevent_payload_t;
 
-// Packet descriptor used for event streaming.
-typedef struct _netevent_message_descriptor
-{
-    unsigned int packet_original_length;
-    unsigned int packet_logged_length;
-    unsigned int packet_metadata_length;
-} netevent_message_descriptor_t;
-
-// Metadata information used for event streaming.
-typedef struct _netevent_message_metadata
-{
-    unsigned long long pkt_group_id;
-    unsigned short pkt_count;
-    unsigned short appearance_count;
-    unsigned short direction_name;
-    unsigned short packet_type;
-    unsigned short component_id;
-    unsigned short edge_id;
-    unsigned short filter_id;
-    unsigned int drop_reason;
-    unsigned int drop_location;
-    unsigned short proc_num;
-    unsigned long long timestamp;
-} netevent_message_metadata_t;
-
-// Packet header used for event streaming.
-typedef struct _netevent_message_header
-{
-    unsigned char event_id;
-    netevent_message_descriptor_t packet_descriptor;
-    netevent_message_metadata_t metadata;
-} netevent_message_header_t;
-
 // This structure is used to pass event data to the eBPF program.
 typedef struct _netevent_message
 {
-    netevent_message_header_t header;
+    PKTMON_EVT_STREAM_PACKET_HEADER header;
     netevent_payload_t payload;
 } netevent_message_t;
 

--- a/tests/neteventebpfext/netevent_sim/netevent_types.h
+++ b/tests/neteventebpfext/netevent_sim/netevent_types.h
@@ -22,13 +22,6 @@ typedef struct _ip_address
     unsigned char octet4;
 } ip_address_t;
 
-// Common header for all events
-typedef struct _event_header
-{
-    unsigned char event_type; ///< Event type. This is the first byte of the event data, for compatibility with
-                              ///< potential usage with Cilium eBPF programs.
-} event_header_t;
-
 // Type definitions for drop events
 typedef enum _drop_reason
 {
@@ -38,18 +31,61 @@ typedef enum _drop_reason
     DROP_REASON_BANDWIDTH_LIMIT = 3,
     DROP_REASON_INACTIVE_TIMEOUT = 4,
 } drop_reason;
-typedef struct _netevent_message
+typedef struct _netevent_payload
 {
-    event_header_t header;
 
     ip_address_t source_ip;
     ip_address_t destination_ip;
     unsigned short source_port;
     unsigned short destination_port;
-    unsigned short reason;
 
     // Event counter, for testing purposes
     unsigned long event_counter;
+} netevent_payload_t;
+
+//
+// Packet descriptor used for event streaming
+//
+typedef struct _netevent_packet_descriptor
+{
+    unsigned int PacketOriginalLength;
+    unsigned int PacketLoggedLength;
+    unsigned int PacketMetaDataLength;
+} netevent_packet_descriptor_t;
+
+//
+// Metadata information used for event streaming
+//
+typedef struct _netevent_stream_metadata
+{
+    unsigned long long PktGroupId;
+    unsigned short PktCount;
+    unsigned short AppearanceCount;
+    unsigned short DirectionName;
+    unsigned short PacketType;
+    unsigned short ComponentId;
+    unsigned short EdgeId;
+    unsigned short FilterId;
+    unsigned int DropReason;
+    unsigned int DropLocation;
+    unsigned short ProcNum;
+    long TimeStamp;
+} netevent_stream_metadata_t;
+
+//
+// Packet header used for event streaming
+//
+typedef struct _netevent_stream_packet_header
+{
+    unsigned char EventId;
+    netevent_packet_descriptor_t PacketDescriptor;
+    netevent_stream_metadata_t Metadata;
+} netevent_stream_packet_header_t;
+
+typedef struct _netevent_messsage
+{
+    netevent_stream_packet_header_t header;
+    netevent_payload_t payload;
 } netevent_message_t;
 
-#pragma pack(pop) // Restore default packing
+#pragma pack(pop)

--- a/tests/neteventebpfext/netevent_sim/netevent_types.h
+++ b/tests/neteventebpfext/netevent_sim/netevent_types.h
@@ -3,11 +3,6 @@
 
 #pragma once
 
-// #include <ntdef.h>
-// typedef struct _EX_RUNDOWN_REF_CACHE_AWARE* PEX_RUNDOWN_REF_CACHE_AWARE;
-// #include <pktmonnpik.h>
-
-// #include "..\..\..\include\ebpf_netevent_hooks.h"
 //
 // Define some demo event types
 //
@@ -48,9 +43,7 @@ typedef struct _netevent_payload
     unsigned long event_counter;
 } netevent_payload_t;
 
-//
-// Packet descriptor used for event streaming
-//
+// Packet descriptor used for event streaming.
 typedef struct _netevent_message_descriptor
 {
     unsigned int packet_original_length;
@@ -58,9 +51,7 @@ typedef struct _netevent_message_descriptor
     unsigned int packet_metadata_length;
 } netevent_message_descriptor_t;
 
-//
-// Metadata information used for event streaming
-//
+// Metadata information used for event streaming.
 typedef struct _netevent_message_metadata
 {
     unsigned long long pkt_group_id;
@@ -77,9 +68,7 @@ typedef struct _netevent_message_metadata
     unsigned long long timestamp;
 } netevent_message_metadata_t;
 
-//
-// Packet header used for event streaming
-//
+// Packet header used for event streaming.
 typedef struct _netevent_message_header
 {
     unsigned char event_id;
@@ -87,9 +76,7 @@ typedef struct _netevent_message_header
     netevent_message_metadata_t metadata;
 } netevent_message_header_t;
 
-//
 // This structure is used to pass event data to the eBPF program.
-//
 typedef struct _netevent_message
 {
     netevent_message_header_t header;

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -53,7 +53,7 @@ _dump_event(uint8_t event_type, const char* event_descr, void* data, size_t size
                   << (int)demo_event->payload.destination_ip.octet3 << "."
                   << (int)demo_event->payload.destination_ip.octet4 << ":" << demo_event->payload.destination_port
                   << ", "
-                  << "reason: " << (int)demo_event->header.Metadata.DropReason;
+                  << "reason: " << (int)demo_event->header.metadata.drop_reason;
         std::cout << "}" << std::flush;
     } else {
         // Simply dump the event data as hex bytes.

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 #define CATCH_CONFIG_MAIN
+// clang-format off
+#include "framework.h"
 #include "..\netevent_sim\netevent_types.h"
+// clang-format on
 #include "catch_wrapper.hpp"
 #include "cxplat_fault_injection.h"
 #include "cxplat_passed_test_log.h"

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -46,14 +46,14 @@ _dump_event(uint8_t event_type, const char* event_descr, void* data, size_t size
         size == sizeof(netevent_payload_t)) {
 
         // Cast the event and print its details
-        netevent_payload_t* demo_payload = reinterpret_cast<netevent_payload_t*>(data);
-        std::cout << "\rNetwork event [" << demo_payload->event_counter << "]: {"
-                  << "src: " << (int)demo_payload->source_ip.octet1 << "." << (int)demo_payload->source_ip.octet2 << "."
-                  << (int)demo_payload->source_ip.octet3 << "." << (int)demo_payload->source_ip.octet4 << ":"
-                  << demo_payload->source_port << ", "
-                  << "dst: " << (int)demo_payload->destination_ip.octet1 << "."
-                  << (int)demo_payload->destination_ip.octet2 << "." << (int)demo_payload->destination_ip.octet3 << "."
-                  << (int)demo_payload->destination_ip.octet4 << ":" << demo_payload->destination_port;
+        netevent_payload_t* test_payload = reinterpret_cast<netevent_payload_t*>(data);
+        std::cout << "\rNetwork event [" << test_payload->event_counter << "]: {"
+                  << "src: " << (int)test_payload->source_ip.octet1 << "." << (int)test_payload->source_ip.octet2 << "."
+                  << (int)test_payload->source_ip.octet3 << "." << (int)test_payload->source_ip.octet4 << ":"
+                  << test_payload->source_port << ", "
+                  << "dst: " << (int)test_payload->destination_ip.octet1 << "."
+                  << (int)test_payload->destination_ip.octet2 << "." << (int)test_payload->destination_ip.octet3 << "."
+                  << (int)test_payload->destination_ip.octet4 << ":" << test_payload->destination_port;
         std::cout << "}" << std::flush;
     } else {
         // Simply dump the event data as hex bytes.

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -43,10 +43,11 @@ void
 _dump_event(uint8_t event_type, const char* event_descr, void* data, size_t size)
 {
     if ((event_type == NOTIFY_EVENT_TYPE_NETEVENT_DROP || event_type == NOTIFY_EVENT_TYPE_NETEVENT_LOG) &&
-        size == sizeof(netevent_payload_t)) {
+        size == sizeof(netevent_message_t)) {
 
         // Cast the event and print its details
-        netevent_payload_t* test_payload = reinterpret_cast<netevent_payload_t*>(data);
+        netevent_message_t* test_message = reinterpret_cast<netevent_message_t*>(data);
+        netevent_payload_t* test_payload = static_cast<netevent_payload_t*>(&test_message->payload);
         std::cout << "\rNetwork event [" << test_payload->event_counter << "]: {"
                   << "src: " << (int)test_payload->source_ip.octet1 << "." << (int)test_payload->source_ip.octet2 << "."
                   << (int)test_payload->source_ip.octet3 << "." << (int)test_payload->source_ip.octet4 << ":"

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -44,14 +44,16 @@ _dump_event(uint8_t event_type, const char* event_descr, void* data, size_t size
 
         // Cast the event and print its details
         netevent_message_t* demo_event = reinterpret_cast<netevent_message_t*>(data);
-        std::cout << "\rNetwork event [" << demo_event->event_counter << "]: {"
-                  << "src: " << (int)demo_event->source_ip.octet1 << "." << (int)demo_event->source_ip.octet2 << "."
-                  << (int)demo_event->source_ip.octet3 << "." << (int)demo_event->source_ip.octet4 << ":"
-                  << demo_event->source_port << ", "
-                  << "dst: " << (int)demo_event->destination_ip.octet1 << "." << (int)demo_event->destination_ip.octet2
-                  << "." << (int)demo_event->destination_ip.octet3 << "." << (int)demo_event->destination_ip.octet4
-                  << ":" << demo_event->destination_port << ", "
-                  << "reason: " << (int)demo_event->reason;
+        std::cout << "\rNetwork event [" << demo_event->payload.event_counter << "]: {"
+                  << "src: " << (int)demo_event->payload.source_ip.octet1 << "."
+                  << (int)demo_event->payload.source_ip.octet2 << "." << (int)demo_event->payload.source_ip.octet3
+                  << "." << (int)demo_event->payload.source_ip.octet4 << ":" << demo_event->payload.source_port << ", "
+                  << "dst: " << (int)demo_event->payload.destination_ip.octet1 << "."
+                  << (int)demo_event->payload.destination_ip.octet2 << "."
+                  << (int)demo_event->payload.destination_ip.octet3 << "."
+                  << (int)demo_event->payload.destination_ip.octet4 << ":" << demo_event->payload.destination_port
+                  << ", "
+                  << "reason: " << (int)demo_event->header.Metadata.DropReason;
         std::cout << "}" << std::flush;
     } else {
         // Simply dump the event data as hex bytes.

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -40,20 +40,17 @@ void
 _dump_event(uint8_t event_type, const char* event_descr, void* data, size_t size)
 {
     if ((event_type == NOTIFY_EVENT_TYPE_NETEVENT_DROP || event_type == NOTIFY_EVENT_TYPE_NETEVENT_LOG) &&
-        size == sizeof(netevent_message_t)) {
+        size == sizeof(netevent_payload_t)) {
 
         // Cast the event and print its details
-        netevent_message_t* demo_event = reinterpret_cast<netevent_message_t*>(data);
-        std::cout << "\rNetwork event [" << demo_event->payload.event_counter << "]: {"
-                  << "src: " << (int)demo_event->payload.source_ip.octet1 << "."
-                  << (int)demo_event->payload.source_ip.octet2 << "." << (int)demo_event->payload.source_ip.octet3
-                  << "." << (int)demo_event->payload.source_ip.octet4 << ":" << demo_event->payload.source_port << ", "
-                  << "dst: " << (int)demo_event->payload.destination_ip.octet1 << "."
-                  << (int)demo_event->payload.destination_ip.octet2 << "."
-                  << (int)demo_event->payload.destination_ip.octet3 << "."
-                  << (int)demo_event->payload.destination_ip.octet4 << ":" << demo_event->payload.destination_port
-                  << ", "
-                  << "reason: " << (int)demo_event->header.metadata.drop_reason;
+        netevent_payload_t* demo_payload = reinterpret_cast<netevent_payload_t*>(data);
+        std::cout << "\rNetwork event [" << demo_payload->event_counter << "]: {"
+                  << "src: " << (int)demo_payload->source_ip.octet1 << "." << (int)demo_payload->source_ip.octet2 << "."
+                  << (int)demo_payload->source_ip.octet3 << "." << (int)demo_payload->source_ip.octet4 << ":"
+                  << demo_payload->source_port << ", "
+                  << "dst: " << (int)demo_payload->destination_ip.octet1 << "."
+                  << (int)demo_payload->destination_ip.octet2 << "." << (int)demo_payload->destination_ip.octet3 << "."
+                  << (int)demo_payload->destination_ip.octet4 << ":" << demo_payload->destination_port;
         std::cout << "}" << std::flush;
     } else {
         // Simply dump the event data as hex bytes.

--- a/tools/netevent_monitor/bpf/netevent_monitor.c
+++ b/tools/netevent_monitor/bpf/netevent_monitor.c
@@ -29,10 +29,6 @@ NetEventMonitor(netevent_event_md_t* ctx)
     int result = -1;
 
     if (ctx != NULL && ctx->data != NULL && ctx->data_end != NULL && ctx->data_end > ctx->data) {
-
-        if (ctx->data_meta != NULL && ctx->data_meta < ctx->data) {
-            bpf_printk("NetEventMonitor: data_meta length: %u\n", (ctx->data - ctx->data_meta));
-        }
         // Push the event to the netevent_events_map.
         // TODO: switch to perf_event_output when it is available.
         // Issue: https://github.com/microsoft/ntosebpfext/issues/204.

--- a/tools/netevent_monitor/bpf/netevent_monitor.c
+++ b/tools/netevent_monitor/bpf/netevent_monitor.c
@@ -32,6 +32,7 @@ NetEventMonitor(netevent_event_md_t* ctx)
         ctx->payload_end > ctx->payload_start) {
 
         // Push the event to the netevent_events_map.
+        // TODO: switch to perf_event_output when it is available.
         result =
             bpf_ringbuf_output(&netevent_events_map, ctx->payload_start, (ctx->payload_end - ctx->payload_start), 0);
     }

--- a/tools/netevent_monitor/bpf/netevent_monitor.c
+++ b/tools/netevent_monitor/bpf/netevent_monitor.c
@@ -28,14 +28,12 @@ NetEventMonitor(netevent_event_md_t* ctx)
 {
     int result = -1;
 
-    if (ctx != NULL && ctx->payload_start != NULL && ctx->payload_end != NULL &&
-        ctx->payload_end > ctx->payload_start) {
+    if (ctx != NULL && ctx->data_start != NULL && ctx->data_end != NULL && ctx->data_end > ctx->data_start) {
 
         // Push the event to the netevent_events_map.
         // TODO: switch to perf_event_output when it is available.
         // Issue: https://github.com/microsoft/ntosebpfext/issues/204.
-        result =
-            bpf_ringbuf_output(&netevent_events_map, ctx->payload_start, (ctx->payload_end - ctx->payload_start), 0);
+        result = bpf_ringbuf_output(&netevent_events_map, ctx->data_start, (ctx->data_end - ctx->data_start), 0);
     }
 
     return result;

--- a/tools/netevent_monitor/bpf/netevent_monitor.c
+++ b/tools/netevent_monitor/bpf/netevent_monitor.c
@@ -28,15 +28,15 @@ NetEventMonitor(netevent_event_md_t* ctx)
 {
     int result = -1;
 
-    if (ctx != NULL && ctx->data_start != NULL && ctx->data_end != NULL && ctx->data_end > ctx->data_start) {
+    if (ctx != NULL && ctx->data != NULL && ctx->data_end != NULL && ctx->data_end > ctx->data) {
 
-        if (ctx->data_meta != NULL && ctx->data_meta < ctx->data_start) {
-            bpf_printk("NetEventMonitor: data_meta length: %u\n", (ctx->data_start - ctx->data_meta));
+        if (ctx->data_meta != NULL && ctx->data_meta < ctx->data) {
+            bpf_printk("NetEventMonitor: data_meta length: %u\n", (ctx->data - ctx->data_meta));
         }
         // Push the event to the netevent_events_map.
         // TODO: switch to perf_event_output when it is available.
         // Issue: https://github.com/microsoft/ntosebpfext/issues/204.
-        result = bpf_ringbuf_output(&netevent_events_map, ctx->data_start, (ctx->data_end - ctx->data_start), 0);
+        result = bpf_ringbuf_output(&netevent_events_map, ctx->data, (ctx->data_end - ctx->data), 0);
     }
 
     return result;

--- a/tools/netevent_monitor/bpf/netevent_monitor.c
+++ b/tools/netevent_monitor/bpf/netevent_monitor.c
@@ -33,6 +33,7 @@ NetEventMonitor(netevent_event_md_t* ctx)
 
         // Push the event to the netevent_events_map.
         // TODO: switch to perf_event_output when it is available.
+        // Issue: https://github.com/microsoft/ntosebpfext/issues/204.
         result =
             bpf_ringbuf_output(&netevent_events_map, ctx->payload_start, (ctx->payload_end - ctx->payload_start), 0);
     }

--- a/tools/netevent_monitor/bpf/netevent_monitor.c
+++ b/tools/netevent_monitor/bpf/netevent_monitor.c
@@ -28,12 +28,12 @@ NetEventMonitor(netevent_event_md_t* ctx)
 {
     int result = -1;
 
-    if (ctx != NULL && ctx->event_data_start != NULL && ctx->event_data_end != NULL &&
-        ctx->event_data_end > ctx->event_data_start) {
+    if (ctx != NULL && ctx->payload_start != NULL && ctx->payload_end != NULL &&
+        ctx->payload_end > ctx->payload_start) {
 
         // Push the event to the netevent_events_map.
-        result = bpf_ringbuf_output(
-            &netevent_events_map, ctx->event_data_start, (ctx->event_data_end - ctx->event_data_start), 0);
+        result =
+            bpf_ringbuf_output(&netevent_events_map, ctx->payload_start, (ctx->payload_end - ctx->payload_start), 0);
     }
 
     return result;

--- a/tools/netevent_monitor/bpf/netevent_monitor.c
+++ b/tools/netevent_monitor/bpf/netevent_monitor.c
@@ -30,6 +30,9 @@ NetEventMonitor(netevent_event_md_t* ctx)
 
     if (ctx != NULL && ctx->data_start != NULL && ctx->data_end != NULL && ctx->data_end > ctx->data_start) {
 
+        if (ctx->data_meta != NULL && ctx->data_meta < ctx->data_start) {
+            bpf_printk("NetEventMonitor: data_meta length: %u\n", (ctx->data_start - ctx->data_meta));
+        }
         // Push the event to the netevent_events_map.
         // TODO: switch to perf_event_output when it is available.
         // Issue: https://github.com/microsoft/ntosebpfext/issues/204.

--- a/wdk.props
+++ b/wdk.props
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
-    <WDKVersion>10.0.26100.2161</WDKVersion>
+    <WDKVersion>10.0.26100.2454</WDKVersion>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" />


### PR DESCRIPTION
## Description
The context passed to netevent BPF programs previously only included start and end pointers. This PR introduces additional data_meta field to the context. Also the netevent_sim now simulates pktmon_netevt events.

Changes Made in the PR:
- The pktmon_netevt structures are now published in WDK 10.0.26100.2454. The WDK version has been updated to ensure the correct WDK NuGet package is installed.
- Logic has been added in netevent.c to convert the flat buffer it receives into a context structure, where the data_meta points to start of the buffer and data_start points to the packet payload.
## Testing

Refactored simulator code and existing tests to test modified changes.

## Documentation

NA

## Installation

NA