### PR TITLE
Update ntosebpfext to consume ebpf v0.21.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,7 +88,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: process_monitor
-      pre_test: powershell -file .\bin\process_monitor.Tests\win-x64\Install-eBpfForWindows.ps1 0.18.0 && powershell -file .\bin\process_monitor.Tests\win-x64\Setup-ProcessMonitorTests.ps1 -ArtifactsRoot .
+      pre_test: powershell -file .\bin\process_monitor.Tests\win-x64\Install-eBpfForWindows.ps1 0.21.0 && powershell -file .\bin\process_monitor.Tests\win-x64\Setup-ProcessMonitorTests.ps1 -ArtifactsRoot .
       test_command: dotnet test .\bin\process_monitor.Tests\win-x64\process_monitor.Tests.dll
       build_artifact: Build-x64
       environment: windows-2022
@@ -102,7 +102,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: neteventebpfext unit tests
-      pre_test: powershell -file .\bin\process_monitor.Tests\win-x64\Install-eBpfForWindows.ps1 0.18.0
+      pre_test: powershell -file .\bin\process_monitor.Tests\win-x64\Install-eBpfForWindows.ps1 0.21.0
       test_command: .\neteventebpfext_unit.exe -d yes
       build_artifact: Build-x64
       environment: windows-2022

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,20 @@
 
 We'd love your help with eBPF for Windows! Here are our contribution guidelines.
 
-- [Code of Conduct](#code-of-conduct)
-- [Bugs](#bugs)
-- [New Features](#new-features)
-- [Building the code](#building-the-code)
-- [Testing the code](#testing-the-code)
-- [Contributor License Agreement](#contributor-license-agreement)
-- [Contributing Code](#contributing-code)
-  - [Tests](#tests)
+- [Contributing to eBPF for Windows](#contributing-to-ebpf-for-windows)
+  - [Code of Conduct](#code-of-conduct)
+  - [Bugs](#bugs)
+    - [Did you find a bug?](#did-you-find-a-bug)
+    - [Did you write a patch that fixes a bug?](#did-you-write-a-patch-that-fixes-a-bug)
+  - [New Features](#new-features)
+  - [Building the code](#building-the-code)
+  - [Testing the code](#testing-the-code)
+    - [Unit tests](#unit-tests)
+    - [E2E tests](#e2e-tests)
+      - [Running the E2E tests in Visual Studio](#running-the-e2e-tests-in-visual-studio)
+    - [Debugging locally](#debugging-locally)
+  - [Contributor License Agreement](#contributor-license-agreement)
+  - [Contributing Code](#contributing-code)
 
  ## Code of Conduct
 
@@ -91,7 +97,7 @@ Do the following once:
 1. Open a command prompt as admin
 1. `cd <your local clone root>`
 1. `cd x64\Debug\bin\process_monitor.Tests\win-x64`
-1. `powershell -file .\Install-eBpfForWindows.ps1 0.18.0`
+1. `powershell -file .\Install-eBpfForWindows.ps1 0.21.0`
 1. `powershell -file .\Setup-ProcessMonitorTests.ps1`
 
 Then do this each time you want to re-run the tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,20 +2,14 @@
 
 We'd love your help with eBPF for Windows! Here are our contribution guidelines.
 
-- [Contributing to eBPF for Windows](#contributing-to-ebpf-for-windows)
-  - [Code of Conduct](#code-of-conduct)
-  - [Bugs](#bugs)
-    - [Did you find a bug?](#did-you-find-a-bug)
-    - [Did you write a patch that fixes a bug?](#did-you-write-a-patch-that-fixes-a-bug)
-  - [New Features](#new-features)
-  - [Building the code](#building-the-code)
-  - [Testing the code](#testing-the-code)
-    - [Unit tests](#unit-tests)
-    - [E2E tests](#e2e-tests)
-      - [Running the E2E tests in Visual Studio](#running-the-e2e-tests-in-visual-studio)
-    - [Debugging locally](#debugging-locally)
-  - [Contributor License Agreement](#contributor-license-agreement)
-  - [Contributing Code](#contributing-code)
+- [Code of Conduct](#code-of-conduct)
+- [Bugs](#bugs)
+- [New Features](#new-features)
+- [Building the code](#building-the-code)
+- [Testing the code](#testing-the-code)
+- [Contributor License Agreement](#contributor-license-agreement)
+- [Contributing Code](#contributing-code)
+  - [Tests](#tests)
 
  ## Code of Conduct
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <!-- Try to keep these in alphabetical order -->
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.4" />
     <PackageVersion Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.4" />
-    <PackageVersion Include="eBPF-for-Windows" Version="0.21" />
+    <PackageVersion Include="eBPF-for-Windows.x64" Version="0.21" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <!-- Try to keep these in alphabetical order -->
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.4" />
     <PackageVersion Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.4" />
-    <PackageVersion Include="eBPF-for-Windows" Version=$(eBPFForWindowsVersion) />
+    <PackageVersion Include="eBPF-for-Windows" Version="$(eBPFForWindowsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,12 +6,11 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\ntosebpfext.props" />
   <ItemGroup>
     <!-- Try to keep these in alphabetical order -->
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.4" />
     <PackageVersion Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.4" />
-    <PackageVersion Include="eBPF-for-Windows" Version="$(eBPFForWindowsVersion)" />
+    <PackageVersion Include="eBPF-for-Windows" Version="0.21" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,11 +6,12 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
   <ItemGroup>
     <!-- Try to keep these in alphabetical order -->
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.4" />
     <PackageVersion Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.4" />
-    <PackageVersion Include="eBPF-for-Windows" Version="0.18.0" />
+    <PackageVersion Include="eBPF-for-Windows" Version=$(eBPFForWindowsVersion) />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -207,7 +207,6 @@ static ebpf_program_data_t _ebpf_netevent_event_program_data = {
     .context_create = _ebpf_netevent_program_context_create,
     .context_destroy = _ebpf_netevent_program_context_destroy,
     .required_irql = PASSIVE_LEVEL,
-    .capabilities = {0},
 };
 static ebpf_extension_data_t _ebpf_netevent_event_program_info_provider_data = {
     .header = {EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_netevent_event_program_data)},

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -237,18 +237,6 @@ _netevent_ebpf_extension_netevent_on_client_attach(
 
     UNREFERENCED_PARAMETER(provider_context);
 
-    if (client_data == NULL ||
-        client_data->header.version < EBPF_ATTACH_CLIENT_DATA_CURRENT_VERSION ||
-        client_data->data_size != sizeof(*attach_opts) ||
-        client_data->data == NULL) {
-        EBPF_EXT_LOG_MESSAGE(
-            EBPF_EXT_TRACELOG_LEVEL_ERROR,
-            EBPF_EXT_TRACELOG_KEYWORD_NETEVENT,
-            "Invalid client data passed to attach.");
-        result = EBPF_INVALID_ARGUMENT;
-        goto Exit;
-    }
-
     if (client_data != NULL && client_data->data != NULL) {
         attach_opts = (netevent_attach_opts_t*)client_data->data;
         if ((attach_opts->capture_type >= NeteventCapture_All) && (attach_opts->capture_type <= NeteventCapture_None)) {

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -237,6 +237,18 @@ _netevent_ebpf_extension_netevent_on_client_attach(
 
     UNREFERENCED_PARAMETER(provider_context);
 
+    if (client_data == NULL ||
+        client_data->header.version < EBPF_ATTACH_CLIENT_DATA_CURRENT_VERSION ||
+        client_data->data_size != sizeof(*attach_opts) ||
+        client_data->data == NULL) {
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_NETEVENT,
+            "Invalid client data passed to attach.");
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
     if (client_data != NULL && client_data->data != NULL) {
         attach_opts = (netevent_attach_opts_t*)client_data->data;
         if ((attach_opts->capture_type >= NeteventCapture_All) && (attach_opts->capture_type <= NeteventCapture_None)) {

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -207,7 +207,7 @@ static ebpf_program_data_t _ebpf_netevent_event_program_data = {
     .context_create = _ebpf_netevent_program_context_create,
     .context_destroy = _ebpf_netevent_program_context_destroy,
     .required_irql = PASSIVE_LEVEL,
-    .capabilities = {.supports_context_header = true},
+    .capabilities = {0},
 };
 static ebpf_extension_data_t _ebpf_netevent_event_program_info_provider_data = {
     .header = {EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_netevent_event_program_data)},

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -248,18 +248,16 @@ _netevent_ebpf_extension_netevent_on_client_attach(
         goto Exit;
     }
 
-    if (client_data != NULL && client_data->data != NULL) {
-        attach_opts = (netevent_attach_opts_t*)client_data->data;
-        if ((attach_opts->capture_type >= NeteventCapture_All) && (attach_opts->capture_type <= NeteventCapture_None)) {
-            _netevent_client_dispatch.capture_type = attach_opts->capture_type;
-        } else {
-            EBPF_EXT_LOG_MESSAGE(
-                EBPF_EXT_TRACELOG_LEVEL_ERROR,
-                EBPF_EXT_TRACELOG_KEYWORD_NETEVENT,
-                "Incorrect capture type in attach opts.");
-            result = EBPF_OPERATION_NOT_SUPPORTED;
-            goto Exit;
-        }
+    attach_opts = (netevent_attach_opts_t*)client_data->data;
+    if ((attach_opts->capture_type >= NeteventCapture_All) && (attach_opts->capture_type <= NeteventCapture_None)) {
+        _netevent_client_dispatch.capture_type = attach_opts->capture_type;
+    } else {
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_NETEVENT,
+            "Incorrect capture type in attach opts.");
+        result = EBPF_OPERATION_NOT_SUPPORTED;
+        goto Exit;
     }
 
     ExAcquirePushLockExclusive(&_ebpf_netevent_event_hook_provider_lock);

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_program_info.h
@@ -7,9 +7,7 @@
 #include "ebpf_netevent_hooks.h"
 #include "ebpf_netevent_program_attach_type_guids.h"
 #include "ebpf_program_types.h"
-
-#define BPF_ATTACH_TYPE_NETEVENT 99900
-#define BPF_PROG_TYPE_NETEVENT 99901
+#include "ebpf_structs.h"
 
 static const ebpf_helper_function_prototype_t _netevent_event_ebpf_extension_helper_function_prototype[] = {
     {.header =

--- a/ebpf_extensions/neteventebpfext/sys/neteventebpfext.vcxproj
+++ b/ebpf_extensions/neteventebpfext/sys/neteventebpfext.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -245,6 +246,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/ebpf_extensions/neteventebpfext/sys/neteventebpfext.vcxproj
+++ b/ebpf_extensions/neteventebpfext/sys/neteventebpfext.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -246,6 +246,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/ebpf_extensions/neteventebpfext/user/neteventebpfext_user.vcxproj
+++ b/ebpf_extensions/neteventebpfext/user/neteventebpfext_user.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -152,6 +153,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/ebpf_extensions/neteventebpfext/user/neteventebpfext_user.vcxproj
+++ b/ebpf_extensions/neteventebpfext/user/neteventebpfext_user.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -153,6 +153,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -53,7 +53,6 @@ static ebpf_program_data_t _ebpf_process_program_data = {
     .context_create = _ebpf_process_context_create,
     .context_destroy = _ebpf_process_context_destroy,
     .required_irql = PASSIVE_LEVEL,
-    .capabilities = {0},
 };
 
 static ebpf_extension_data_t _ebpf_process_program_info_provider_data = {

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -53,7 +53,7 @@ static ebpf_program_data_t _ebpf_process_program_data = {
     .context_create = _ebpf_process_context_create,
     .context_destroy = _ebpf_process_context_destroy,
     .required_irql = PASSIVE_LEVEL,
-    .capabilities = {.supports_context_header = true},
+    .capabilities = {0},
 };
 
 static ebpf_extension_data_t _ebpf_process_program_info_provider_data = {

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_program_info.h
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_program_info.h
@@ -7,6 +7,7 @@
 #include "ebpf_ntos_hooks.h"
 #include "ebpf_ntos_program_attach_type_guids.h"
 #include "ebpf_program_types.h"
+#include "ebpf_structs.h"
 
 // Process program information.
 static const ebpf_helper_function_prototype_t _process_ebpf_extension_helper_function_prototype[] = {
@@ -24,10 +25,6 @@ static const ebpf_context_descriptor_t _ebpf_process_context_descriptor = {
     EBPF_OFFSET_OF(process_md_t, command_end),
     -1,
 };
-
-// Need to allocate these in ebpf_structs.h in ebpf-for-windows repo.
-#define BPF_PROG_TYPE_PROCESS 99999
-#define BPF_ATTACH_TYPE_PROCESS 99999
 
 static const ebpf_program_type_descriptor_t _ebpf_process_program_type_descriptor = {
     .header = {EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION, EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION_SIZE},

--- a/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
+++ b/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -161,6 +162,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
+++ b/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -162,6 +162,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/ebpf_extensions/ntosebpfext/user/ntosebpfext_user.vcxproj
+++ b/ebpf_extensions/ntosebpfext/user/ntosebpfext_user.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -122,6 +122,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/ebpf_extensions/ntosebpfext/user/ntosebpfext_user.vcxproj
+++ b/ebpf_extensions/ntosebpfext/user/ntosebpfext_user.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -121,6 +122,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/ntosebpfext.props
+++ b/ntosebpfext.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <!-- eBPF -->
     <eBPFForWindowsVersion>0.21.0</eBPFForWindowsVersion>
-    <eBPFForWindowsPackagePath>$(SolutionDir)packages\eBPF-for-Windows.x64.$(eBPFForWindowsVersion)\</eBPFForWindowsPackagePath>
+    <eBPFForWindowsPackagePath>$(SolutionDir)packages\eBPF-for-Windows.x64.$(eBPFForWindowsVersion)</eBPFForWindowsPackagePath>
   </PropertyGroup>
 </Project>

--- a/ntosebpfext.props
+++ b/ntosebpfext.props
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- eBPF -->
+    <eBPFForWindowsVersion>0.21.0</eBPFForWindowsVersion>
+    <eBPFForWindowsPackagePath>$(SolutionDir)packages\eBPF-for-Windows.x64.$(eBPFForWindowsVersion)\</eBPFForWindowsPackagePath>
+  </PropertyGroup>
+</Project>

--- a/scripts/Install-eBpfForWindows.ps1
+++ b/scripts/Install-eBpfForWindows.ps1
@@ -7,7 +7,7 @@ param(
 )
 
 # Define the URL to download the eBPF for Windows installer
-$installer_url = "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v%%VER%%/ebpf-for-windows.%%VER%%.msi"
+$installer_url = "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v%%VER%%/ebpf-for-windows.x64.%%VER%%.msi"
 $installer_url = $installer_url -replace "%%VER%%", $version
 
 # Define the path to download the eBPF for Windows installer

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -13,8 +13,8 @@ $commands = @(
     "cmake -G 'Visual Studio 17 2022' -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF",
     "nuget restore ntosebpfext.sln",
     "Get-ChildItem -Path .\ -Recurse",
-    "Test-Path -Path .\pacakges\eBPF-for-Windows.0.21.0\build\native\bin\export_program_info.exe",
-    ".\packages\eBPF-for-Windows.0.21.0\build\native\bin\export_program_info.exe"
+    "Test-Path -Path .\pacakges\eBPF-for-Windows.x64.0.21.0\build\native\bin\export_program_info.exe",
+    ".\packages\eBPF-for-Windows.x64.0.21.0\build\native\bin\export_program_info.exe"
 )
 
 # Loop through each command and run them sequentially without opening a new window

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -12,7 +12,9 @@ $commands = @(
     "git submodule update --init --recursive",
     "cmake -G 'Visual Studio 17 2022' -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF",
     "nuget restore ntosebpfext.sln",
-    "packages\eBPF-for-Windows.0.21.0\build\native\bin\export_program_info.exe"
+    "Get-ChildItem -Path .\ -Recurse",
+    "Test-Path -Path .\pacakges\eBPF-for-Windows.0.21.0\build\native\bin\export_program_info.exe",
+    ".\packages\eBPF-for-Windows.0.21.0\build\native\bin\export_program_info.exe"
 )
 
 # Loop through each command and run them sequentially without opening a new window

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -12,8 +12,6 @@ $commands = @(
     "git submodule update --init --recursive",
     "cmake -G 'Visual Studio 17 2022' -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF",
     "nuget restore ntosebpfext.sln",
-    "Get-ChildItem -Path .\ -Recurse",
-    "Test-Path -Path .\pacakges\eBPF-for-Windows.x64.0.21.0\build\native\bin\export_program_info.exe",
     ".\packages\eBPF-for-Windows.x64.0.21.0\build\native\bin\export_program_info.exe"
 )
 

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -12,7 +12,7 @@ $commands = @(
     "git submodule update --init --recursive",
     "cmake -G 'Visual Studio 17 2022' -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF",
     "nuget restore ntosebpfext.sln",
-    "packages\eBPF-for-Windows.0.18.0\build\native\bin\export_program_info.exe"
+    "packages\eBPF-for-Windows.0.21.0\build\native\bin\export_program_info.exe"
 )
 
 # Loop through each command and run them sequentially without opening a new window

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows" version="0.18.0" targetFramework="native" />
+  <package id="eBPF-for-Windows" version="0.21.0" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2454" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2454" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2454" targetFramework="native" />

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows" version="0.21.0" targetFramework="native" />
+  <package id="eBPF-for-Windows.x64" version="0.21.0" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2454" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2454" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2454" targetFramework="native" />

--- a/scripts/setup_build/setup_build.vcxproj
+++ b/scripts/setup_build/setup_build.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -119,6 +119,6 @@ copy "$(EbpfBinPath)\ebpfapi.dll" $(OutDir)</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/scripts/setup_build/setup_build.vcxproj
+++ b/scripts/setup_build/setup_build.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -118,6 +119,6 @@ copy "$(EbpfBinPath)\ebpfapi.dll" $(OutDir)</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj
@@ -3,7 +3,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -175,6 +176,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj
+++ b/tests/neteventebpfext/netevent_sim/netevent_sim.vcxproj
@@ -4,7 +4,7 @@
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -176,6 +176,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -430,10 +430,10 @@ TEST_CASE("netevent_bpf_prog_run_test", "[neteventebpfext]")
 
     // Prepare bpf_opts
     bpf_opts.repeat = 1;
-    bpf_opts.ctx_in = &netevent_ctx_in;
-    bpf_opts.ctx_size_in = sizeof(netevent_ctx_in);
-    bpf_opts.ctx_out = &netevent_ctx_out;
-    bpf_opts.ctx_size_out = sizeof(netevent_ctx_out);
+    bpf_opts.ctx_in = &netevent_ctx_in.context;
+    bpf_opts.ctx_size_in = sizeof(netevent_ctx_in.context);
+    bpf_opts.ctx_out = &netevent_ctx_out.context;
+    bpf_opts.ctx_size_out = sizeof(netevent_ctx_out.context);
     bpf_opts.data_in = &dummy_data_in;
     bpf_opts.data_size_in = static_cast<uint32_t>(dummy_data_size);
     // Set the data_out buffer to hold the output.

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -236,12 +236,15 @@ TEST_CASE("netevent_drivers_load_unload_stress", "[neteventebpfext]")
     REQUIRE(res == 0);
 
     // Find and attach to the netevent_monitor BPF program.
+    ebpf_result_t result;
+    bpf_link* netevent_monitor_link = nullptr;
     netevent_attach_opts_t attach_opts = {
         .capture_type = NeteventCapture_All
     };
     auto netevent_monitor = bpf_object__find_program_by_name(object, "NetEventMonitor");
     REQUIRE(netevent_monitor != nullptr);
-    auto netevent_monitor_link = bpf_program__attach(netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts));
+    result = ebpf_program_attach(netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts), &netevent_monitor_link);
+    REQUIRE(result == EBPF_SUCCESS);
     REQUIRE(netevent_monitor_link != nullptr);
 
     // Attach to the eBPF ring buffer event map.
@@ -344,12 +347,15 @@ TEST_CASE("netevent_bpf_prog_run_test", "[neteventebpfext]")
     REQUIRE(res == 0);
 
     // Find and attach to the netevent_monitor BPF program.
+    ebpf_result_t result;
+    bpf_link* netevent_monitor_link = nullptr;
     netevent_attach_opts_t attach_opts = {
         .capture_type = NeteventCapture_All
     };
     bpf_program* netevent_monitor = bpf_object__find_program_by_name(object, "NetEventMonitor");
     REQUIRE(netevent_monitor != nullptr);
-    bpf_link* netevent_monitor_link = bpf_program__attach(netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts));
+    result = ebpf_program_attach(netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts), &netevent_monitor_link);
+    REQUIRE(result == EBPF_SUCCESS);
     REQUIRE(netevent_monitor_link != nullptr);
 
     // Attach to the eBPF ring buffer event map.

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -100,75 +100,6 @@ netevent_monitor_event_callback(void* ctx, void* data, size_t size)
     return 0;
 }
 
-TEST_CASE("netevent_event_simulation", "[neteventebpfext]")
-{
-    // Free the BPF object will take some time to unload from the previous test
-    // Once this issue is fixed, the sleep can be removed: https://github.com/microsoft/ebpf-for-windows/issues/2667
-    std::this_thread::sleep_for(std::chrono::seconds(10));
-
-    // First, load the netevent simulator driver (NPI provider).
-    driver_service netevent_sim_driver;
-    REQUIRE(
-        netevent_sim_driver.create(L"netevent_sim", driver_service::get_driver_path("netevent_sim.sys").c_str()) ==
-        true);
-    REQUIRE(netevent_sim_driver.start() == true);
-
-    // Load and start neteventebpfext extension driver.
-    driver_service neteventebpfext_driver;
-    REQUIRE(
-        neteventebpfext_driver.create(
-            L"neteventebpfext", driver_service::get_driver_path("neteventebpfext.sys").c_str()) == true);
-    REQUIRE(neteventebpfext_driver.start() == true);
-
-    // Load the NetEventMonitor native BPF program.
-    struct bpf_object* object = bpf_object__open("netevent_monitor.sys");
-    REQUIRE(object != nullptr);
-
-    int res = bpf_object__load(object);
-    REQUIRE(res == 0);
-
-    // Find and attach to the netevent_monitor BPF program.
-    auto netevent_monitor = bpf_object__find_program_by_name(object, "NetEventMonitor");
-    REQUIRE(netevent_monitor != nullptr);
-    auto netevent_monitor_link = bpf_program__attach(netevent_monitor);
-    REQUIRE(netevent_monitor_link != nullptr);
-
-    // Attach to the eBPF ring buffer event map.
-    bpf_map* netevent_events_map = bpf_object__find_map_by_name(object, "netevent_events_map");
-    REQUIRE(netevent_events_map != nullptr);
-    auto ring = ring_buffer__new(bpf_map__fd(netevent_events_map), netevent_monitor_event_callback, nullptr, nullptr);
-    REQUIRE(ring != nullptr);
-
-    // Wait for the number of expected events or the test's max run time.
-    int timeout = NETEVENT_EVENT_TEST_TIMEOUT_SEC;
-    while (event_count < MAX_EVENTS_COUNT && timeout-- > 0) {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-
-    // Test the event count and ensure the test didn't time out.
-    REQUIRE(event_count >= MAX_EVENTS_COUNT);
-    REQUIRE(timeout > 0);
-
-    // Detach the program (link) from the attach point.
-    int link_fd = bpf_link__fd(netevent_monitor_link);
-    bpf_link_detach(link_fd);
-    bpf_link__destroy(netevent_monitor_link);
-
-    // Close ring buffer.
-    ring_buffer__free(ring);
-
-    // Free the BPF object.
-    bpf_object__close(object);
-
-    // First, stop and unload the netevent simulator driver (NPI provider).
-    REQUIRE(netevent_sim_driver.stop() == true);
-    REQUIRE(netevent_sim_driver.unload() == true);
-
-    // Stop and unload the neteventebpfext extension driver (NPI client).
-    REQUIRE(neteventebpfext_driver.stop() == true);
-    REQUIRE(neteventebpfext_driver.unload() == true);
-}
-
 TEST_CASE("netevent_attach_opt_simulation", "[neteventebpfext]")
 {
     // Free the BPF object will take some time to unload from the previous test
@@ -206,9 +137,12 @@ TEST_CASE("netevent_attach_opt_simulation", "[neteventebpfext]")
     auto ring = ring_buffer__new(bpf_map__fd(netevent_events_map), netevent_monitor_event_callback, nullptr, nullptr);
     REQUIRE(ring != nullptr);
 
+    // Test attach with no attach params
+    result = ebpf_program_attach(netevent_monitor);
+    REQUIRE(result != EBPF_SUCCESS);
+    REQUIRE(netevent_monitor_link == nullptr);
+
     // Test attach with invalid capture type
-    ebpf_result_t result;
-    bpf_link* netevent_monitor_link = nullptr;
     netevent_attach_opts_t attach_opts = {};
     attach_opts.capture_type = (netevent_capture_type_t)0;
     result = ebpf_program_attach(
@@ -300,9 +234,12 @@ TEST_CASE("netevent_drivers_load_unload_stress", "[neteventebpfext]")
     REQUIRE(res == 0);
 
     // Find and attach to the netevent_monitor BPF program.
+    netevent_attach_opts_t attach_opts = {
+        .capture_type = NeteventCapture_All
+    };
     auto netevent_monitor = bpf_object__find_program_by_name(object, "NetEventMonitor");
     REQUIRE(netevent_monitor != nullptr);
-    auto netevent_monitor_link = bpf_program__attach(netevent_monitor);
+    auto netevent_monitor_link = bpf_program__attach(netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts));
     REQUIRE(netevent_monitor_link != nullptr);
 
     // Attach to the eBPF ring buffer event map.
@@ -405,9 +342,12 @@ TEST_CASE("netevent_bpf_prog_run_test", "[neteventebpfext]")
     REQUIRE(res == 0);
 
     // Find and attach to the netevent_monitor BPF program.
+    netevent_attach_opts_t attach_opts = {
+        .capture_type = NeteventCapture_All
+    };
     bpf_program* netevent_monitor = bpf_object__find_program_by_name(object, "NetEventMonitor");
     REQUIRE(netevent_monitor != nullptr);
-    bpf_link* netevent_monitor_link = bpf_program__attach(netevent_monitor);
+    bpf_link* netevent_monitor_link = bpf_program__attach(netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts));
     REQUIRE(netevent_monitor_link != nullptr);
 
     // Attach to the eBPF ring buffer event map.

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -144,8 +144,18 @@ TEST_CASE("netevent_attach_opt_simulation", "[neteventebpfext]")
     REQUIRE(result != EBPF_SUCCESS);
     REQUIRE(netevent_monitor_link == nullptr);
 
-    // Test attach with invalid capture type - this should fail.
+    // Test attach with invalid size (too small) - this should fail.
     netevent_attach_opts_t attach_opts = {};
+    result = ebpf_program_attach(
+        netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts) - 1, &netevent_monitor_link);
+    REQUIRE(result != EBPF_SUCCESS);
+
+    // Test attach with invalid size (too large) - this should fail.
+    result = ebpf_program_attach(
+        netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts) - 1, &netevent_monitor_link);
+    REQUIRE(result != EBPF_SUCCESS);
+
+    // Test attach with invalid capture type - this should fail.
     attach_opts.capture_type = (netevent_capture_type_t)0;
     result = ebpf_program_attach(
         netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, &attach_opts, sizeof(attach_opts), &netevent_monitor_link);

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -419,8 +419,10 @@ TEST_CASE("netevent_bpf_prog_run_test", "[neteventebpfext]")
 
     // Initialize structures required for bpf_prog_test_run_opts
     bpf_test_run_opts bpf_opts = {0};
-    test_netevent_event_md_t netevent_ctx_in = {0};
-    test_netevent_event_md_t netevent_ctx_out = {0};
+    test_netevent_event_md_t test_netevent_ctx_in = {0};
+    test_netevent_event_md_t test_netevent_ctx_out = {0};
+    netevent_event_md_t& netevent_ctx_in = test_netevent_ctx_in.context;
+    netevent_event_md_t& netevent_ctx_out = test_netevent_ctx_out.context;
     unsigned char dummy_data_in[] = {NOTIFY_EVENT_TYPE_NETEVENT_DROP, 'a', 'b'};
     const size_t dummy_data_size = sizeof(dummy_data_in);
     unsigned char data_out[MAX_PACKET_SIZE] = {0};
@@ -430,10 +432,10 @@ TEST_CASE("netevent_bpf_prog_run_test", "[neteventebpfext]")
 
     // Prepare bpf_opts
     bpf_opts.repeat = 1;
-    bpf_opts.ctx_in = &netevent_ctx_in.context;
-    bpf_opts.ctx_size_in = sizeof(netevent_ctx_in.context);
-    bpf_opts.ctx_out = &netevent_ctx_out.context;
-    bpf_opts.ctx_size_out = sizeof(netevent_ctx_out.context);
+    bpf_opts.ctx_in = &netevent_ctx_in;
+    bpf_opts.ctx_size_in = sizeof(netevent_ctx_in);
+    bpf_opts.ctx_out = &netevent_ctx_out;
+    bpf_opts.ctx_size_out = sizeof(netevent_ctx_out);
     bpf_opts.data_in = &dummy_data_in;
     bpf_opts.data_size_in = static_cast<uint32_t>(dummy_data_size);
     // Set the data_out buffer to hold the output.

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -39,6 +39,12 @@ static volatile uint32_t event_count = 0;
 static volatile uint32_t log_event_count = 0;
 static volatile uint32_t drop_event_count = 0;
 
+typedef struct test_netevent_event_md
+{
+    EBPF_CONTEXT_HEADER;
+    netevent_event_md_t context;
+} test_netevent_event_md_t;
+
 void
 _dump_event(uint8_t event_type, const char* event_descr, void* data, size_t size)
 {
@@ -413,8 +419,8 @@ TEST_CASE("netevent_bpf_prog_run_test", "[neteventebpfext]")
 
     // Initialize structures required for bpf_prog_test_run_opts
     bpf_test_run_opts bpf_opts = {0};
-    netevent_event_md_t netevent_ctx_in = {0};
-    netevent_event_md_t netevent_ctx_out = {0};
+    test_netevent_event_md_t netevent_ctx_in = {0};
+    test_netevent_event_md_t netevent_ctx_out = {0};
     unsigned char dummy_data_in[] = {NOTIFY_EVENT_TYPE_NETEVENT_DROP, 'a', 'b'};
     const size_t dummy_data_size = sizeof(dummy_data_in);
     unsigned char data_out[MAX_PACKET_SIZE] = {0};

--- a/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
+++ b/tests/neteventebpfext/neteventebpfext_unit/netevent_ebpfext_unit.cpp
@@ -137,12 +137,14 @@ TEST_CASE("netevent_attach_opt_simulation", "[neteventebpfext]")
     auto ring = ring_buffer__new(bpf_map__fd(netevent_events_map), netevent_monitor_event_callback, nullptr, nullptr);
     REQUIRE(ring != nullptr);
 
-    // Test attach with no attach params
-    result = ebpf_program_attach(netevent_monitor);
+    // Test attach with no attach params - this should fail.
+    ebpf_result_t result;
+    bpf_link* netevent_monitor_link = nullptr;
+    result = ebpf_program_attach(netevent_monitor, &EBPF_ATTACH_TYPE_NETEVENT, nullptr, 0, &netevent_monitor_link);
     REQUIRE(result != EBPF_SUCCESS);
     REQUIRE(netevent_monitor_link == nullptr);
 
-    // Test attach with invalid capture type
+    // Test attach with invalid capture type - this should fail.
     netevent_attach_opts_t attach_opts = {};
     attach_opts.capture_type = (netevent_capture_type_t)0;
     result = ebpf_program_attach(

--- a/tests/neteventebpfext/neteventebpfext_unit/neteventebpfext_unit.vcxproj
+++ b/tests/neteventebpfext/neteventebpfext_unit/neteventebpfext_unit.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -166,6 +167,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tests/neteventebpfext/neteventebpfext_unit/neteventebpfext_unit.vcxproj
+++ b/tests/neteventebpfext/neteventebpfext_unit/neteventebpfext_unit.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -167,6 +167,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/tests/ntosebpfext/ntosebpfext_unit/ntosebpfext_unit.vcxproj
+++ b/tests/ntosebpfext/ntosebpfext_unit/ntosebpfext_unit.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -124,6 +124,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/tests/ntosebpfext/ntosebpfext_unit/ntosebpfext_unit.vcxproj
+++ b/tests/ntosebpfext/ntosebpfext_unit/ntosebpfext_unit.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -123,6 +124,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tools/netevent_ebpf_ext_export_program_info/netevent_ebpf_ext_export_program_info.vcxproj
+++ b/tools/netevent_ebpf_ext_export_program_info/netevent_ebpf_ext_export_program_info.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -229,6 +230,6 @@ $(OutDir)netevent_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tools/netevent_ebpf_ext_export_program_info/netevent_ebpf_ext_export_program_info.vcxproj
+++ b/tools/netevent_ebpf_ext_export_program_info/netevent_ebpf_ext_export_program_info.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -230,6 +230,6 @@ $(OutDir)netevent_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/tools/netevent_monitor/netevent_monitor.vcxproj
+++ b/tools/netevent_monitor/netevent_monitor.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -185,6 +185,6 @@ $(Outdir)netevent_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/tools/netevent_monitor/netevent_monitor.vcxproj
+++ b/tools/netevent_monitor/netevent_monitor.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -184,6 +185,6 @@ $(Outdir)netevent_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tools/ntos_ebpf_ext_export_program_info/ntos_ebpf_ext_export_program_info.vcxproj
+++ b/tools/ntos_ebpf_ext_export_program_info/ntos_ebpf_ext_export_program_info.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -191,6 +191,6 @@ $(OutDir)ntos_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/tools/ntos_ebpf_ext_export_program_info/ntos_ebpf_ext_export_program_info.vcxproj
+++ b/tools/ntos_ebpf_ext_export_program_info/ntos_ebpf_ext_export_program_info.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -190,6 +191,6 @@ $(OutDir)ntos_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>

--- a/tools/nuget/nuget.proj
+++ b/tools/nuget/nuget.proj
@@ -19,10 +19,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="eBPF-for-Windows" />
-  </ItemGroup>
-
   <Target Name="_Get_NetNativeContent" BeforeTargets="PrepareForBuild;_IntermediatePack">
     <ItemGroup>
       <None Include="README.md" PackagePath="." Pack="true" />

--- a/tools/process_monitor.Library/process_monitor.Library.csproj
+++ b/tools/process_monitor.Library/process_monitor.Library.csproj
@@ -3,18 +3,18 @@
   SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
 
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="eBPF-for-Windows" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="$(PkgeBPF-for-Windows)\build\native\bin\EbpfApi.dll">
+    <Content Include="$(eBPFForWindowsPackagePath)\build\native\bin\EbpfApi.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\$(Platform)\$(Configuration)\process_monitor.sys" Link="process_monitor.sys">

--- a/tools/process_monitor_bpf/process_monitor_bpf.vcxproj
+++ b/tools/process_monitor_bpf/process_monitor_bpf.vcxproj
@@ -5,7 +5,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ntosebpfext.props" />
-  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -116,6 +116,6 @@ $(Outdir)ntos_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.x64.props'))" />
   </Target>
 </Project>

--- a/tools/process_monitor_bpf/process_monitor_bpf.vcxproj
+++ b/tools/process_monitor_bpf/process_monitor_bpf.vcxproj
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props" Condition="Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" />
+  <Import Project="$(SolutionDir)\ntosebpfext.props" />
+  <Import Project="$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props" Condition="Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -115,6 +116,6 @@ $(Outdir)ntos_ebpf_ext_export_program_info.exe</Command>
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\eBPF-for-Windows.0.18.0\build\native\ebpf-for-windows.props'))" />
+    <Error Condition="!Exists('$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(eBPFForWindowsPackagePath)\build\native\ebpf-for-windows.props'))" />
   </Target>
 </Project>


### PR DESCRIPTION
## Description
- Added a new ntosebpfext.props to add vcxproj definitions
- Updated ebpf-for-windows version to 0.21
- Removed PROG_TYPE and ATTACH_TYPE and replaced with consuming ebpf_structs.h (as they were moved there)
- Update program info capabilities to consume the 0.21 breaking change
- Add missing attach params validation in neteventext

## Testing
Updates to neteventext unit tests to validate attach params.

## Documentation
n/a

## Installation
n/a