### PR TITLE
Add .props file in NuGet package for auto-import and include path update

### DIFF
--- a/tools/nuget/ebpf-for-windows.extensions.props
+++ b/tools/nuget/ebpf-for-windows.extensions.props
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
+  <PropertyGroup>
+    <EbpfExtensionsIncludePath>$(MSBuildThisFileDirectory)include</EbpfExtensionsIncludePath>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(EbpfExtensionsIncludePath);</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/tools/nuget/nuget.proj
+++ b/tools/nuget/nuget.proj
@@ -22,6 +22,7 @@
   <Target Name="_Get_NetNativeContent" BeforeTargets="PrepareForBuild;_IntermediatePack">
     <ItemGroup>
       <None Include="README.md" PackagePath="." Pack="true" />
+      <None Include="ebpf-for-windows.extensions.props" PackagePath="build\native\$(PackageId).props" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\ntosebpfext.sys" PackagePath="build\native\bin" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\ntosebpfext.pdb" PackagePath="build\native\bin" Pack="true" />
       <None Include="..\..\include\ebpf_ntos_hooks.h" PackagePath="build\native\include" Pack="true" />


### PR DESCRIPTION
## Description

Add .props file for auto-import and include path update. Enables auto-update of consuming project's `AdditionalIncludeDirectories` so manual update isn't necessary.

Resolves #219

## Testing

Built package, consumed in external project, verified no extra code was needed to update include path.

## Documentation

N/A

## Installation

N/A