### PR TITLE
Update Onebranch packaging for internal build pipeline

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -176,6 +176,11 @@ jobs:
         path: ${{github.workspace}}/build-${{ matrix.configurations }}.zip
         retention-days: 5
 
+    - name: Copy required scripts to build output
+      if: inputs.build_nuget == true && matrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
+      run: |
+        Copy-Item -Path scripts\Install-Extension.ps1 -Destination ${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}} -Force
+
     - name: Build the NuGet package
       if: inputs.build_nuget == true && matrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -11,16 +11,17 @@ Set-Location $scriptPath\..\..
 
 $OneBranchArch = $env:ONEBRANCH_ARCH
 $OneBranchConfig = $env:ONEBRANCH_CONFIG
-$SignedBinFolder = ".\build\bin\$($OneBranchArch)_$($OneBranchConfig)"
-$DestinationFolder = ".\build\bin\$($OneBranchArch)_$($OneBranchConfig)"
+# Folder where the build output is located. Note that these may not be signed.
 $BuildFolder = ".\$($OneBranchArch)\$($OneBranchConfig)"
+# Folder where the signed binaries are located.
+$SignedOutputFolder = ".\build\bin\$($OneBranchArch)_$($OneBranchConfig)"
 
 # Produce a zip file of the signed binaries
-$OutputZipFolder = Join-Path $DestinationFolder "Build-$($OneBranchArch)-$($OneBranchConfig).zip"
-Compress-Archive -Path $SignedBinFolder -DestinationPath $OutputZipFolder
+$OutputZipFile = Join-Path $SignedOutputFolder "Build-$($OneBranchArch)-$($OneBranchConfig).zip"
+Compress-Archive -Path $SignedOutputFolder -DestinationPath $OutputZipFile
 
-# Copy signed binaries to the output directory for usage in the nuget package creation.
-xcopy /y $SignedBinFolder $BuildFolder
+# Copy signed binaries to the build output directory for usage in the nuget package creation.
+xcopy /y $SignedOutputFolder $BuildFolder
 
 # Create the nuget package with the signed binaries.
 Import-Module "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
@@ -30,7 +31,7 @@ $SolutionDir = Get-Location
 msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false .\tools\nuget\nuget.proj /t:Restore,Build,Pack
 
 # Copy the nuget package to the output directory.
-$DestinationNupkgPath = Join-Path $DestinationFolder "packages"
+$DestinationNupkgPath = Join-Path $SignedOutputFolder "packages"
 if (-not (Test-Path -Path $DestinationNupkgPath)) {
     New-Item -ItemType Directory -Path $DestinationNupkgPath
 }

--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -12,42 +12,16 @@ Set-Location $scriptPath\..\..
 $OneBranchArch = $env:ONEBRANCH_ARCH
 $OneBranchConfig = $env:ONEBRANCH_CONFIG
 
-function Copy-BuildFolder {
-    param (
-        [Parameter(Mandatory=$true)]
-        [ValidateSet("Release", "Debug")]
-        [string]$Configuration, 
-        [Parameter(Mandatory=$true)]
-        [string]$Arch
-    )
-
-    # Define the source folder and zip file path based on the configuration
-    $SourceFolder = ".\$Arch\$Configuration"
-    $ZipFile = ".\build\bin\$($Arch)_$($Configuration)\Build-$($Arch)-$($Configuration).zip"
-
-    # Remove any existing zip file to avoid conflicts
-    if (Test-Path $ZipFile) {
-        Remove-Item $ZipFile
-    }
-
-    # Compress the folder into a zip file
-    Compress-Archive -Path $SourceFolder -DestinationPath $ZipFile
-
-    Write-Host "$SourceFolder folder has been zipped into $ZipFile"
-}
-
 # Copy the signed binaries to the output directory
 if ($OneBranchConfig -eq "Debug" -and $OneBranchArch -eq "x64") {
     xcopy /y build\bin\x64_Debug .\x64\Debug
     xcopy /y build\bin\x64_Debug\Install-Extension.ps1 .\scripts\
     Get-ChildItem -Path .\build\bin\x64_Debug -Recurse | Remove-Item -Force -Recurse
-}
-elseif ($OneBranchConfig -eq "Release" -and $OneBranchArch -eq "x64") {
+} elseif ($OneBranchConfig -eq "Release" -and $OneBranchArch -eq "x64") {
     xcopy /y build\bin\x64_Release .\x64\Release
     xcopy /y build\bin\x64_Release\Install-Extension.ps1 .\scripts\
     Get-ChildItem -Path .\build\bin\x64_Release -Recurse | Remove-Item -Force -Recurse
-}
-else {
+} else {
     throw ("Configuration $OneBranchConfig|$OneBranchArch is not supported.")
 }
 
@@ -66,4 +40,3 @@ if (-not (Test-Path -Path $DestinationNupkgPath)) {
 }
 
 xcopy /y $SourceNupkgPath $DestinationNupkgPath
-Copy-BuildFolder -Configuration $OneBranchConfig -Arch $OneBranchArch

--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -11,59 +11,27 @@ Set-Location $scriptPath\..\..
 
 $OneBranchArch = $env:ONEBRANCH_ARCH
 $OneBranchConfig = $env:ONEBRANCH_CONFIG
+$SignedBinFolder = ".\build\bin\$($OneBranchArch)_$($OneBranchConfig)"
+$DestinationFolder = ".\build\bin\$($OneBranchArch)_$($OneBranchConfig)"
+$BuildFolder = ".\$($OneBranchArch)\$($OneBranchConfig)"
 
-function Copy-BuildFolder {
-    param (
-        [Parameter(Mandatory=$true)]
-        [ValidateSet("Release", "Debug")]
-        [string]$Configuration, 
-        [Parameter(Mandatory=$true)]
-        [string]$Arch
-    )
+# Produce a zip file of the signed binaries
+$OutputZipFolder = Join-Path $DestinationFolder "Build-$($OneBranchArch)-$($OneBranchConfig).zip"
+Compress-Archive -Path $SignedBinFolder -DestinationPath $OutputZipFolder
 
-    # Define the source folder and zip file path based on the configuration
-    $SourceFolder = ".\$Arch\$Configuration"
-    $ZipFile = ".\build\bin\$($Arch)_$($Configuration)\Build-$($Arch)-$($Configuration).zip"
+# Copy signed binaries to the output directory for usage in the nuget package creation.
+xcopy /y $SignedBinFolder $BuildFolder
 
-    # Remove any existing zip file to avoid conflicts
-    if (Test-Path $ZipFile) {
-        Remove-Item $ZipFile
-    }
-
-    # Compress the folder into a zip file
-    Compress-Archive -Path $SourceFolder -DestinationPath $ZipFile
-
-    Write-Host "$SourceFolder folder has been zipped into $ZipFile"
-}
-
-# Copy the signed binaries to the output directory
-if ($OneBranchConfig -eq "Debug" -and $OneBranchArch -eq "x64") {
-    xcopy /y build\bin\x64_Debug .\x64\Debug
-    xcopy /y build\bin\x64_Debug\Install-Extension.ps1 .\scripts\
-    Get-ChildItem -Path .\build\bin\x64_Debug -Recurse | Remove-Item -Force -Recurse
-}
-elseif ($OneBranchConfig -eq "Release" -and $OneBranchArch -eq "x64") {
-    xcopy /y build\bin\x64_Release .\x64\Release
-    xcopy /y build\bin\x64_Release\Install-Extension.ps1 .\scripts\
-    Get-ChildItem -Path .\build\bin\x64_Release -Recurse | Remove-Item -Force -Recurse
-}
-else {
-    throw ("Configuration $OneBranchConfig|$OneBranchArch is not supported.")
-}
-
+# Create the nuget package with the signed binaries.
 Import-Module "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
 Enter-VsDevShell -VsInstallPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"  -DevCmdArguments "-arch=x64 -host_arch=x64"
 Set-Location $scriptPath\..\..
 $SolutionDir = Get-Location
 msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false .\tools\nuget\nuget.proj /t:Restore,Build,Pack
 
-$SourceNupkgPath = ".\$OneBranchArch\$OneBranchConfig\*.nupkg"
-# Copy the nupkg to the 'packages' subdirectory in the output directory (default used by onebranch pipelines to publish nupkgs)
-$DestinationNupkgPath = ".\build\bin\$OneBranchArch`_$OneBranchConfig\packages"
-
+# Copy the nuget package to the output directory.
+$DestinationNupkgPath = Join-Path $DestinationFolder "packages"
 if (-not (Test-Path -Path $DestinationNupkgPath)) {
     New-Item -ItemType Directory -Path $DestinationNupkgPath
 }
-
-xcopy /y $SourceNupkgPath $DestinationNupkgPath
-Copy-BuildFolder -Configuration $OneBranchConfig -Arch $OneBranchArch
+xcopy /y $BuildFolder\*.nupkg $DestinationNupkgPath

--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -12,16 +12,42 @@ Set-Location $scriptPath\..\..
 $OneBranchArch = $env:ONEBRANCH_ARCH
 $OneBranchConfig = $env:ONEBRANCH_CONFIG
 
+function Copy-BuildFolder {
+    param (
+        [Parameter(Mandatory=$true)]
+        [ValidateSet("Release", "Debug")]
+        [string]$Configuration, 
+        [Parameter(Mandatory=$true)]
+        [string]$Arch
+    )
+
+    # Define the source folder and zip file path based on the configuration
+    $SourceFolder = ".\$Arch\$Configuration"
+    $ZipFile = ".\build\bin\$($Arch)_$($Configuration)\Build-$($Arch)-$($Configuration).zip"
+
+    # Remove any existing zip file to avoid conflicts
+    if (Test-Path $ZipFile) {
+        Remove-Item $ZipFile
+    }
+
+    # Compress the folder into a zip file
+    Compress-Archive -Path $SourceFolder -DestinationPath $ZipFile
+
+    Write-Host "$SourceFolder folder has been zipped into $ZipFile"
+}
+
 # Copy the signed binaries to the output directory
 if ($OneBranchConfig -eq "Debug" -and $OneBranchArch -eq "x64") {
     xcopy /y build\bin\x64_Debug .\x64\Debug
     xcopy /y build\bin\x64_Debug\Install-Extension.ps1 .\scripts\
     Get-ChildItem -Path .\build\bin\x64_Debug -Recurse | Remove-Item -Force -Recurse
-} elseif ($OneBranchConfig -eq "Release" -and $OneBranchArch -eq "x64") {
+}
+elseif ($OneBranchConfig -eq "Release" -and $OneBranchArch -eq "x64") {
     xcopy /y build\bin\x64_Release .\x64\Release
     xcopy /y build\bin\x64_Release\Install-Extension.ps1 .\scripts\
     Get-ChildItem -Path .\build\bin\x64_Release -Recurse | Remove-Item -Force -Recurse
-} else {
+}
+else {
     throw ("Configuration $OneBranchConfig|$OneBranchArch is not supported.")
 }
 
@@ -40,3 +66,4 @@ if (-not (Test-Path -Path $DestinationNupkgPath)) {
 }
 
 xcopy /y $SourceNupkgPath $DestinationNupkgPath
+Copy-BuildFolder -Configuration $OneBranchConfig -Arch $OneBranchArch

--- a/scripts/onebranch/pre-build.ps1
+++ b/scripts/onebranch/pre-build.ps1
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 
+$OneBranchArch = $env:ONEBRANCH_ARCH
+$OneBranchConfig = $env:ONEBRANCH_CONFIG
+$OutputBinFolder = ".\build\bin\$($OneBranchArch)_$($OneBranchConfig)"
+
 # Get the path where this script is located
 $scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
@@ -10,8 +14,14 @@ Set-Location $scriptPath\..\..
 try {
     Copy-Item .\scripts\onebranch\nuget.config .\nuget.config
     .\scripts\initialize_repo.ps1
-}
-catch {
+
+    # Copy any scripts that will be packaged into the output folder
+    $OutputScriptsFolder = Join-Path $OutputBinFolder "scripts"
+    if (-not (Test-Path -Path $OutputScriptsFolder)) {
+        New-Item -ItemType Directory -Path $OutputScriptsFolder -Force
+    }
+    Copy-Item .\scripts\Install-Extension.ps1 $OutputScriptsFolder
+} catch {
     throw "Failed to initialize the repository."
 }
 

--- a/tools/nuget/nuget.proj
+++ b/tools/nuget/nuget.proj
@@ -35,7 +35,7 @@
       <None Include="..\..\include\ebpf_netevent_program_attach_type_guids.h" PackagePath="build\native\include" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\netevent_ebpf_ext_export_program_info.exe" PackagePath="build\native\bin" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\netevent_ebpf_ext_export_program_info.pdb" PackagePath="build\native\bin" Pack="true" />
-      <None Include="..\..\$(Platform\$(Configuration)scripts\Install-Extension.ps1" PackagePath="build\native\bin" Pack="true" />
+      <None Include="..\..\$(Platform)\$(Configuration)scripts\Install-Extension.ps1" PackagePath="build\native\bin" Pack="true" />
     </ItemGroup>
   </Target>
 </Project>

--- a/tools/nuget/nuget.proj
+++ b/tools/nuget/nuget.proj
@@ -35,7 +35,7 @@
       <None Include="..\..\include\ebpf_netevent_program_attach_type_guids.h" PackagePath="build\native\include" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\netevent_ebpf_ext_export_program_info.exe" PackagePath="build\native\bin" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\netevent_ebpf_ext_export_program_info.pdb" PackagePath="build\native\bin" Pack="true" />
-      <None Include="..\..\$(Platform)\$(Configuration)scripts\Install-Extension.ps1" PackagePath="build\native\bin" Pack="true" />
+      <None Include="..\..\$(Platform)\$(Configuration)\scripts\Install-Extension.ps1" PackagePath="build\native\bin" Pack="true" />
     </ItemGroup>
   </Target>
 </Project>

--- a/tools/nuget/nuget.proj
+++ b/tools/nuget/nuget.proj
@@ -35,7 +35,7 @@
       <None Include="..\..\include\ebpf_netevent_program_attach_type_guids.h" PackagePath="build\native\include" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\netevent_ebpf_ext_export_program_info.exe" PackagePath="build\native\bin" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\netevent_ebpf_ext_export_program_info.pdb" PackagePath="build\native\bin" Pack="true" />
-      <None Include="..\..\scripts\Install-Extension.ps1" PackagePath="build\native\bin" Pack="true" />
+      <None Include="..\..\$(Platform\$(Configuration)scripts\Install-Extension.ps1" PackagePath="build\native\bin" Pack="true" />
     </ItemGroup>
   </Target>
 </Project>

--- a/tools/nuget/nuget.proj
+++ b/tools/nuget/nuget.proj
@@ -35,7 +35,7 @@
       <None Include="..\..\include\ebpf_netevent_program_attach_type_guids.h" PackagePath="build\native\include" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\netevent_ebpf_ext_export_program_info.exe" PackagePath="build\native\bin" Pack="true" />
       <None Include="..\..\$(Platform)\$(Configuration)\netevent_ebpf_ext_export_program_info.pdb" PackagePath="build\native\bin" Pack="true" />
-      <None Include="..\..\$(Platform)\$(Configuration)\scripts\Install-Extension.ps1" PackagePath="build\native\bin" Pack="true" />
+      <None Include="..\..\$(Platform)\$(Configuration)\Install-Extension.ps1" PackagePath="build\native\bin" Pack="true" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
This change has the following:
- Updates the pre_build step to copy the Install-Extension.ps1 script into the build output folder, to allow for build processing
- Updates logic in the post_build step to ensure that we are pulling from the proper binaries
- Updates the nuget package to utilize the post-processed Install-Extension.ps1 script