### PR TITLE
Remove spin lock

### DIFF
--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -328,6 +328,9 @@ ebpf_ext_register_netevent()
 
     EBPF_EXT_LOG_ENTRY();
 
+    size_t event_buffers_array_size = 0;
+    size_t event_buffer_sizes_array_size = 0;
+
     const ebpf_extension_program_info_provider_parameters_t program_info_provider_parameters = {
         &_ebpf_netevent_event_program_info_provider_moduleid, &_ebpf_netevent_event_program_data};
     const ebpf_extension_hook_provider_parameters_t hook_provider_parameters = {
@@ -369,12 +372,14 @@ ebpf_ext_register_netevent()
 
     // initialize per-cpu event buffers
     cpu_count = KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS);
+    event_buffers_array_size = cpu_count * sizeof(uint8_t*);
+    event_buffer_sizes_array_size = cpu_count * sizeof(uint8_t*);
 
     _event_buffers = (uint8_t**)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, cpu_count * sizeof(uint8_t*), EBPF_NETEVENT_EXTENSION_POOL_TAG);
+        NonPagedPoolNx, event_buffers_array_size, EBPF_NETEVENT_EXTENSION_POOL_TAG);
 
     _event_buffer_sizes = (size_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, cpu_count * sizeof(size_t), EBPF_NETEVENT_EXTENSION_POOL_TAG);
+        NonPagedPoolNx, event_buffer_sizes_array_size, EBPF_NETEVENT_EXTENSION_POOL_TAG);
 
     if (_event_buffers == NULL || _event_buffer_sizes == NULL) {
         status = STATUS_INSUFFICIENT_RESOURCES;

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -603,7 +603,7 @@ _ebpf_netevent_push_event(_In_ netevent_event_t* netevent_event)
         goto Exit;
     }
 
-    if (current_cpu > _cpu_count) {
+    if (current_cpu >= _cpu_count) {
         EBPF_EXT_LOG_MESSAGE(
             EBPF_EXT_TRACELOG_LEVEL_ERROR,
             EBPF_EXT_TRACELOG_KEYWORD_NETEVENT,

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -376,6 +376,16 @@ ebpf_ext_register_netevent()
     _event_buffer_sizes = (size_t*)ExAllocatePoolUninitialized(
         NonPagedPoolNx, cpu_count * sizeof(size_t), EBPF_NETEVENT_EXTENSION_POOL_TAG);
 
+    if (_event_buffers == NULL || _event_buffer_sizes == NULL) {
+        status = STATUS_INSUFFICIENT_RESOURCES;
+        EBPF_EXT_LOG_MESSAGE_NTSTATUS(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_NETEVENT,
+            "Insufficient memory initializing the event buffer array",
+            status);
+        goto Exit;
+    }
+
     for (size_t i = 0; i < cpu_count; i++) {
         // Allocate a buffer for each CPU.
         _event_buffer_sizes[i] = INIT_EVENT_BUFFER_SIZE;

--- a/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
+++ b/ebpf_extensions/neteventebpfext/netevent_ebpf_ext_event.c
@@ -584,15 +584,16 @@ _ebpf_netevent_push_event(_In_ netevent_event_t* netevent_event)
     uint8_t* _event_buffer_data_start = NULL;
     uint8_t* data_start = netevent_event->event_start + NETEVENT_HEADER_LENGTH;
     uint64_t payload_size = netevent_event->event_end - netevent_event->event_start;
+    uint32_t current_cpu;
     // Currently, the verifier does not support read-only contexts, so we need to copy the event data, rather than
     // directly passing the existing pointers.
     // Verifier feature proposal: https://github.com/vbpf/ebpf-verifier/issues/639
 
     KIRQL old_irql = KeGetCurrentIrql();
-    uint32_t current_cpu = KeGetCurrentProcessorNumberEx(NULL);
     if (old_irql < DISPATCH_LEVEL) {
         old_irql = KeRaiseIrqlToDpcLevel();
     }
+    current_cpu = KeGetCurrentProcessorNumberEx(NULL);
 
     if (_event_buffers == NULL || _event_buffer_sizes == NULL) {
         EBPF_EXT_LOG_MESSAGE(


### PR DESCRIPTION
## Description

Removed spin lock guard around event_buffer operations by replacing it with per-cpu event buffers.
Closes #206 

## Testing

NA

## Documentation

NA

## Installation

NA