### PR TITLE
Add Dependabot configuration for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@
 
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
@@ -18,7 +17,6 @@ updates:
       actions:
         patterns:
           - "*"
-
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
@@ -28,7 +26,6 @@ updates:
       actions:
         patterns:
           - "*"
-
   - package-ecosystem: "docker"
     directory: "/images"
     schedule:
@@ -38,3 +35,13 @@ updates:
       actions:
         patterns:
           - "*"
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically manage .NET SDK version updates in global.json.

This configuration will:
- Monitor the global.json file for .NET SDK version updates
- Create pull requests when new SDK versions are available
- Help keep the project secure with the latest SDK patches

For more information, see: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/