### PR TITLE
Update WDK from 10.0.26100.2454 to 10.0.26100.4204

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,4 +91,8 @@
     <ArtifactsPath>$(MSBuildThisFileDirectory)\$(Platform)\$(Configuration)</ArtifactsPath>
     <ArtifactsPivots>$(RuntimeIdentifier)</ArtifactsPivots>
   </PropertyGroup>
+  <!-- Workaround for issue with WDK nuget package -->
+  <PropertyGroup>
+    <DriverCatalog_Enable>true</DriverCatalog_Enable>
+  </PropertyGroup>
 </Project>

--- a/scripts/setup_build/packages.config
+++ b/scripts/setup_build/packages.config
@@ -1,18 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="eBPF-for-Windows.x64" version="0.21.0" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2454" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2454" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2454" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.2454" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2454" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2454" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2454" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2161" targetFramework="native" />
-  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x86" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.4204" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x86" version="10.0.26100.4204" targetFramework="native" />
 </packages>

--- a/wdk.props
+++ b/wdk.props
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
-    <WDKVersion>10.0.26100.2454</WDKVersion>
+    <WDKVersion>10.0.26100.4204</WDKVersion>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" />


### PR DESCRIPTION
## Description
Bumping WDK version to match ebpf-for-windows repo (https://github.com/microsoft/ebpf-for-windows/commit/b2babceba564fea80a2b8296869801b9473a7e85)
This pull request updates the Windows SDK and WDK package versions across the build configuration to `10.0.26100.4204`, and introduces a workaround for a known issue with the WDK NuGet package. It also updates the `usersim` submodule to a newer commit.

**Build configuration and dependency updates:**

* Updated all references to the Windows SDK and WDK packages in `scripts/setup_build/packages.config` to version `10.0.26100.4204`, removing older versions.
* Changed the `WDKVersion` property in `wdk.props` to `10.0.26100.4204` to match the new package version.

**Workaround for WDK NuGet package issue:**

* Added the `DriverCatalog_Enable` property set to `true` in `Directory.Build.props` to address a known issue with the WDK NuGet package.

**Submodule update:**

* Updated the `usersim` external submodule to a newer commit (`7b5f0d7...`).
## Testing

NA
## Documentation

NA

## Installation

NA