### PR TITLE
Add MSBuild property in NuGet package specifying binary path

### DIFF
--- a/tools/nuget/ebpf-for-windows.extensions.props
+++ b/tools/nuget/ebpf-for-windows.extensions.props
@@ -2,6 +2,7 @@
 <!-- Copyright (c) Microsoft Corporation -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
   <PropertyGroup>
+    <EbpfExtensionsBinPath>$(MSBuildThisFileDirectory)bin</EbpfExtensionsBinPath>
     <EbpfExtensionsIncludePath>$(MSBuildThisFileDirectory)include</EbpfExtensionsIncludePath>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

Enable NuGet package consumers to access the binaries in the package predictably as is possible for the include/header directory. Currently, consumers have to manually determine and assume the location of the `bin` directory.

Resolves #284

## Testing

Generated the package locally, consumed it in a test project and ensured that `<EbpfExtensionsBinPath>` pointed to `build\native\bin` from which the project invoked `$(EbpfExtensionsBinPath)\netevent_ebpf_ext_export_program_info.exe` successfully.

## Documentation

No documentation impact.

## Installation

No installer impact.
