### PR TITLE
Add SID to ntos hook context

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/catchorg/Catch2.git
 [submodule "external/usersim"]
 	path = external/usersim
-	url = https://github.com/LakshK98/usersim.git
+	url = https://github.com/microsoft/usersim.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/catchorg/Catch2.git
 [submodule "external/usersim"]
 	path = external/usersim
-	url = https://github.com/microsoft/usersim.git
+	url = https://github.com/LakshK98/usersim.git

--- a/docs/ntosebpfext.md
+++ b/docs/ntosebpfext.md
@@ -102,6 +102,8 @@ typedef struct _process_md
     uint64_t exit_time;                ///< Process exit time (as a FILETIME). Set only for PROCESS_OPERATION_DELETE.
     uint32_t process_exit_code;        ///< Process exit status. Set only for PROCESS_OPERATION_DELETE.
     process_operation_t operation : 8; ///< Operation to do.
+    uint32_t token_sid_size;           ///< Size of the token SID in bytes. Set only for PROCESS_OPERATION_CREATE.
+    uint8_t token_sid[TOKEN_SID_MAX_SIZE]; ///< Primary token SID. Set only for PROCESS_OPERATION_CREATE.
 } process_md_t;
 ```
 
@@ -203,6 +205,10 @@ The `process_md_t` structure provides comprehensive information about process ev
 
 - **Exit Information:**
   - `process_exit_code` - The process exit code (only valid for `PROCESS_OPERATION_DELETE`)
+
+- **Token Information:**
+  - `token_sid_size` - Size of the primary token SID in bytes (only valid for `PROCESS_OPERATION_CREATE`)
+  - `token_sid` - The raw SID bytes of the new process's primary token (only valid for `PROCESS_OPERATION_CREATE`). Maximum size is `TOKEN_SID_MAX_SIZE` (68 bytes).
 
 - **Operation Type:**
   - `operation` - Either `PROCESS_OPERATION_CREATE` or `PROCESS_OPERATION_DELETE`

--- a/docs/ntosebpfext.md
+++ b/docs/ntosebpfext.md
@@ -147,7 +147,7 @@ The extension supports attaching multiple eBPF programs, to which process events
 
 ### Helper Functions
 
-The `ntosebpfext` extension provides a custom helper function:
+The `ntosebpfext` extension provides custom helper functions:
 
 #### `bpf_process_get_image_path`
 
@@ -185,6 +185,40 @@ ProcessHandler(process_md_t* ctx)
     return 0;
 }
 ```
+
+#### `bpf_process_get_account_name`
+
+```c
+int bpf_process_get_account_name(process_md_t* ctx, uint8_t* name, uint32_t name_length);
+```
+
+**Description:** Retrieves the account name associated with the process's primary token.
+
+**Parameters:**
+- `ctx` - Process metadata context
+- `name` - Buffer to store the account name (UTF-16 encoded)
+- `name_length` - Length of the buffer in bytes
+
+**Returns:**
+- `>= 0` - The length of the account name in bytes
+- `< 0` - A failure occurred
+
+#### `bpf_process_get_account_domain`
+
+```c
+int bpf_process_get_account_domain(process_md_t* ctx, uint8_t* domain, uint32_t domain_length);
+```
+
+**Description:** Retrieves the account domain associated with the process's primary token.
+
+**Parameters:**
+- `ctx` - Process metadata context
+- `domain` - Buffer to store the account domain (UTF-16 encoded)
+- `domain_length` - Length of the buffer in bytes
+
+**Returns:**
+- `>= 0` - The length of the account domain in bytes
+- `< 0` - A failure occurred
 
 ### Process Context Information
 
@@ -250,7 +284,7 @@ The ntosebpfext extension uses the Windows kernel's `PsSetCreateProcessNotifyRou
 - **Program Info Provider** - Registers the `process` program type with eBPF for Windows
 - **Hook Provider** - Manages the attachment of eBPF programs to process events
 - **Context Creation/Destruction** - Handles the lifecycle of the `process_md_t` context
-- **Helper Functions** - Provides the `bpf_process_get_image_path` helper
+- **Helper Functions** - Provides the `bpf_process_get_image_path`, `bpf_process_get_account_name`, and `bpf_process_get_account_domain` helpers
 
 ## Use Cases
 

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -12,6 +12,7 @@
 #include "shared_context.h"
 
 #include <errno.h>
+#include <limits.h>
 
 // Maximum number of bytes for inline account name/domain buffers on the stack.
 #define ACCOUNT_STRING_INLINE_BYTES 80
@@ -253,6 +254,45 @@ typedef struct _process_notify_context
     BOOLEAN account_lookup_done;
 } process_notify_context_t;
 
+// Deep-copy a UNICODE_STRING from a packed data buffer, advancing the data pointer.
+static ebpf_result_t
+_deep_copy_unicode_string_from_data(
+    _Out_ UNICODE_STRING* dest, _In_ const UNICODE_STRING* src_descriptor, _Inout_ const uint8_t** data_ptr)
+{
+    if (src_descriptor->Length == 0) {
+        RtlInitUnicodeString(dest, NULL);
+        return EBPF_SUCCESS;
+    }
+    dest->Buffer =
+        (PWSTR)ExAllocatePoolUninitialized(NonPagedPoolNx, src_descriptor->MaximumLength, EBPF_EXTENSION_POOL_TAG);
+    if (dest->Buffer == NULL) {
+        return EBPF_NO_MEMORY;
+    }
+#pragma warning(push)
+#pragma warning(disable : 6386) // Length <= MaximumLength validated by caller.
+    memcpy(dest->Buffer, *data_ptr, src_descriptor->Length);
+#pragma warning(pop)
+    dest->Length = src_descriptor->Length;
+    dest->MaximumLength = src_descriptor->MaximumLength;
+    *data_ptr += src_descriptor->Length;
+    return EBPF_SUCCESS;
+}
+
+// Copy a UNICODE_STRING's content into a caller-supplied byte buffer.
+static int32_t
+_copy_unicode_string_to_buffer(
+    _In_ const UNICODE_STRING* source, _Out_writes_bytes_(dest_length) uint8_t* dest, uint32_t dest_length)
+{
+    if (source->Length > dest_length) {
+        return -EINVAL;
+    }
+    if (source->Buffer != NULL && source->Length > 0) {
+        memcpy(dest, source->Buffer, source->Length);
+        return (int32_t)source->Length;
+    }
+    return 0;
+}
+
 static ebpf_result_t
 _ebpf_process_context_create(
     _In_reads_bytes_opt_(data_size_in) const uint8_t* data_in,
@@ -315,108 +355,43 @@ _ebpf_process_context_create(
     // Test contexts have account data provided in data_in, so skip lazy lookup.
     process_context->account_lookup_done = TRUE;
 
-    // Parse data_in buffer: [command_line data][image_file_name data]
-    // The lengths are specified in the UNICODE_STRING structures from the context
+    // Parse data_in buffer: [command_line][image_file_name][account_name][account_domain]
+    // The lengths are specified in the UNICODE_STRING structures from the context.
 
-    // Deep copy command_line buffer from data_in if present
-    if (input_context->command_line.Length > 0) {
-        process_context->command_line.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-            NonPagedPoolNx, input_context->command_line.MaximumLength, EBPF_EXTENSION_POOL_TAG);
-        if (process_context->command_line.Buffer == NULL) {
-            EBPF_EXT_LOG_MESSAGE(
-                EBPF_EXT_TRACELOG_LEVEL_ERROR,
-                EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
-                "Failed to allocate command_line buffer");
-            result = EBPF_NO_MEMORY;
-            goto Exit;
-        }
-        memcpy(process_context->command_line.Buffer, data_ptr, input_context->command_line.Length);
-        process_context->command_line.Length = input_context->command_line.Length;
-        process_context->command_line.MaximumLength = input_context->command_line.MaximumLength;
-
-        data_ptr += input_context->command_line.Length;
-    } else {
-        process_context->command_line.Buffer = NULL;
-        process_context->command_line.Length = 0;
-        process_context->command_line.MaximumLength = 0;
+    result =
+        _deep_copy_unicode_string_from_data(&process_context->command_line, &input_context->command_line, &data_ptr);
+    if (result != EBPF_SUCCESS) {
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR, EBPF_EXT_TRACELOG_KEYWORD_PROCESS, "Failed to allocate command_line buffer");
+        goto Exit;
     }
 
-    // Deep copy image_file_name buffer from data_in if present
-    if (input_context->image_file_name.Length > 0) {
-        process_context->image_file_name.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-            NonPagedPoolNx, input_context->image_file_name.MaximumLength, EBPF_EXTENSION_POOL_TAG);
-        if (process_context->image_file_name.Buffer == NULL) {
-            EBPF_EXT_LOG_MESSAGE(
-                EBPF_EXT_TRACELOG_LEVEL_ERROR,
-                EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
-                "Failed to allocate image_file_name buffer");
-            result = EBPF_NO_MEMORY;
-            goto Exit;
-        }
-#pragma warning(push)
-#pragma warning(disable : 6386) // Length <= MaximumLength validated above.
-        memcpy(process_context->image_file_name.Buffer, data_ptr, input_context->image_file_name.Length);
-#pragma warning(pop)
-        process_context->image_file_name.Length = input_context->image_file_name.Length;
-        process_context->image_file_name.MaximumLength = input_context->image_file_name.MaximumLength;
-
-        data_ptr += input_context->image_file_name.Length;
-    } else {
-        process_context->image_file_name.Buffer = NULL;
-        process_context->image_file_name.Length = 0;
-        process_context->image_file_name.MaximumLength = 0;
+    result = _deep_copy_unicode_string_from_data(
+        &process_context->image_file_name, &input_context->image_file_name, &data_ptr);
+    if (result != EBPF_SUCCESS) {
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
+            "Failed to allocate image_file_name buffer");
+        goto Exit;
     }
 
-    // Deep copy account_name buffer from data_in if present
-    if (input_context->account_name.Length > 0) {
-        process_context->account_name.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-            NonPagedPoolNx, input_context->account_name.MaximumLength, EBPF_EXTENSION_POOL_TAG);
-        if (process_context->account_name.Buffer == NULL) {
-            EBPF_EXT_LOG_MESSAGE(
-                EBPF_EXT_TRACELOG_LEVEL_ERROR,
-                EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
-                "Failed to allocate account_name buffer");
-            result = EBPF_NO_MEMORY;
-            goto Exit;
-        }
-#pragma warning(push)
-#pragma warning(disable : 6386) // Length <= MaximumLength validated above.
-        memcpy(process_context->account_name.Buffer, data_ptr, input_context->account_name.Length);
-#pragma warning(pop)
-        process_context->account_name.Length = input_context->account_name.Length;
-        process_context->account_name.MaximumLength = input_context->account_name.MaximumLength;
-
-        data_ptr += input_context->account_name.Length;
-    } else {
-        process_context->account_name.Buffer = NULL;
-        process_context->account_name.Length = 0;
-        process_context->account_name.MaximumLength = 0;
+    result =
+        _deep_copy_unicode_string_from_data(&process_context->account_name, &input_context->account_name, &data_ptr);
+    if (result != EBPF_SUCCESS) {
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR, EBPF_EXT_TRACELOG_KEYWORD_PROCESS, "Failed to allocate account_name buffer");
+        goto Exit;
     }
 
-    // Deep copy account_domain buffer from data_in if present
-    if (input_context->account_domain.Length > 0) {
-        process_context->account_domain.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-            NonPagedPoolNx, input_context->account_domain.MaximumLength, EBPF_EXTENSION_POOL_TAG);
-        if (process_context->account_domain.Buffer == NULL) {
-            EBPF_EXT_LOG_MESSAGE(
-                EBPF_EXT_TRACELOG_LEVEL_ERROR,
-                EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
-                "Failed to allocate account_domain buffer");
-            result = EBPF_NO_MEMORY;
-            goto Exit;
-        }
-#pragma warning(push)
-#pragma warning(disable : 6386) // Length <= MaximumLength validated above.
-        memcpy(process_context->account_domain.Buffer, data_ptr, input_context->account_domain.Length);
-#pragma warning(pop)
-        process_context->account_domain.Length = input_context->account_domain.Length;
-        process_context->account_domain.MaximumLength = input_context->account_domain.MaximumLength;
-
-        data_ptr += input_context->account_domain.Length;
-    } else {
-        process_context->account_domain.Buffer = NULL;
-        process_context->account_domain.Length = 0;
-        process_context->account_domain.MaximumLength = 0;
+    result = _deep_copy_unicode_string_from_data(
+        &process_context->account_domain, &input_context->account_domain, &data_ptr);
+    if (result != EBPF_SUCCESS) {
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
+            "Failed to allocate account_domain buffer");
+        goto Exit;
     }
 
     // Set command_start and command_end to point to the copied command_line buffer
@@ -662,18 +637,7 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_image_path(
 {
     process_notify_context_t* process_notify_context =
         CONTAINING_RECORD(process_md, process_notify_context_t, process_md);
-    int32_t result = 0;
-    if (process_notify_context->image_file_name.Length > path_length) {
-        return -EINVAL;
-    }
-    if (process_notify_context->image_file_name.Buffer != NULL) {
-        if (path_length >= process_notify_context->image_file_name.Length) {
-            memcpy(
-                path, process_notify_context->image_file_name.Buffer, process_notify_context->image_file_name.Length);
-            result = process_notify_context->image_file_name.Length;
-        }
-    }
-    return result;
+    return _copy_unicode_string_to_buffer(&process_notify_context->image_file_name, path, path_length);
 }
 
 // Lazily resolve the account name and domain from the process token SID.
@@ -732,6 +696,12 @@ _ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_c
         &name_use);
 
     if (status == STATUS_BUFFER_TOO_SMALL) {
+        // Guard against USHORT truncation when casting ULONG sizes.
+        if (name_size > USHRT_MAX || domain_size > USHRT_MAX) {
+            status = STATUS_BUFFER_OVERFLOW;
+            goto Exit;
+        }
+
         // Stack buffers too small — heap-allocate with the returned sizes and retry.
         if (name_size > process_notify_context->account_name.MaximumLength) {
             PWSTR new_buf = (PWSTR)ExAllocatePoolUninitialized(NonPagedPoolNx, name_size, EBPF_EXTENSION_POOL_TAG);
@@ -770,9 +740,10 @@ _ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_c
         goto Exit;
     }
 
-    process_notify_context->account_lookup_done = TRUE;
-
 Exit:
+    // Cache the result unconditionally (success or failure) to avoid redundant
+    // kernel API calls if multiple eBPF programs invoke account helpers.
+    process_notify_context->account_lookup_done = TRUE;
     if (!NT_SUCCESS(status)) {
         // Clear account results on failure.
         if (name_heap_allocated) {
@@ -802,7 +773,6 @@ Exit:
 _Success_(return >= 0) static int32_t _ebpf_process_get_account_name(
     _In_ process_md_t* process_md, _Out_writes_bytes_(name_length) uint8_t* name, uint32_t name_length)
 {
-    int32_t result = 0;
     process_notify_context_t* process_notify_context =
         CONTAINING_RECORD(process_md, process_notify_context_t, process_md);
     NTSTATUS status = _ebpf_process_resolve_account(process_notify_context);
@@ -812,28 +782,14 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_account_name(
             EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
             "Failed to resolve account name",
             status);
-        result = -ENOENT;
-        goto Exit;
+        return -ENOENT;
     }
-    if (process_notify_context->account_name.Length > name_length) {
-        result = -EINVAL;
-        goto Exit;
-    }
-    if (process_notify_context->account_name.Buffer != NULL) {
-        if (name_length >= process_notify_context->account_name.Length) {
-            memcpy(name, process_notify_context->account_name.Buffer, process_notify_context->account_name.Length);
-            result = process_notify_context->account_name.Length;
-        }
-    }
-
-Exit:
-    return result;
+    return _copy_unicode_string_to_buffer(&process_notify_context->account_name, name, name_length);
 }
 
 _Success_(return >= 0) static int32_t _ebpf_process_get_account_domain(
     _In_ process_md_t* process_md, _Out_writes_bytes_(domain_length) uint8_t* domain, uint32_t domain_length)
 {
-    int32_t result = 0;
     process_notify_context_t* process_notify_context =
         CONTAINING_RECORD(process_md, process_notify_context_t, process_md);
     NTSTATUS status = _ebpf_process_resolve_account(process_notify_context);
@@ -843,21 +799,7 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_account_domain(
             EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
             "Failed to resolve account domain",
             status);
-        result = -ENOENT;
-        goto Exit;
+        return -ENOENT;
     }
-    if (process_notify_context->account_domain.Length > domain_length) {
-        result = -EINVAL;
-        goto Exit;
-    }
-    if (process_notify_context->account_domain.Buffer != NULL) {
-        if (domain_length >= process_notify_context->account_domain.Length) {
-            memcpy(
-                domain, process_notify_context->account_domain.Buffer, process_notify_context->account_domain.Length);
-            result = process_notify_context->account_domain.Length;
-        }
-    }
-
-Exit:
-    return result;
+    return _copy_unicode_string_to_buffer(&process_notify_context->account_domain, domain, domain_length);
 }

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -352,7 +352,10 @@ _ebpf_process_context_create(
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
+#pragma warning(push)
+#pragma warning(disable : 6386) // Length <= MaximumLength validated above.
         memcpy(process_context->image_file_name.Buffer, data_ptr, input_context->image_file_name.Length);
+#pragma warning(pop)
         process_context->image_file_name.Length = input_context->image_file_name.Length;
         process_context->image_file_name.MaximumLength = input_context->image_file_name.MaximumLength;
 
@@ -375,7 +378,10 @@ _ebpf_process_context_create(
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
+#pragma warning(push)
+#pragma warning(disable : 6386) // Length <= MaximumLength validated above.
         memcpy(process_context->account_name.Buffer, data_ptr, input_context->account_name.Length);
+#pragma warning(pop)
         process_context->account_name.Length = input_context->account_name.Length;
         process_context->account_name.MaximumLength = input_context->account_name.MaximumLength;
 
@@ -398,7 +404,10 @@ _ebpf_process_context_create(
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
+#pragma warning(push)
+#pragma warning(disable : 6386) // Length <= MaximumLength validated above.
         memcpy(process_context->account_domain.Buffer, data_ptr, input_context->account_domain.Length);
+#pragma warning(pop)
         process_context->account_domain.Length = input_context->account_domain.Length;
         process_context->account_domain.MaximumLength = input_context->account_domain.MaximumLength;
 

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -38,7 +38,17 @@ _ebpf_process_create_process_notify_routine_ex(
 _Success_(return >= 0) static int32_t _ebpf_process_get_image_path(
     _In_ process_md_t* process_md, _Out_writes_bytes_(path_length) uint8_t* path, uint32_t path_length);
 
-static const void* _ebpf_process_helper_functions[] = {(void*)&_ebpf_process_get_image_path};
+_Success_(return >= 0) static int32_t _ebpf_process_get_account_name(
+    _In_ process_md_t* process_md, _Out_writes_bytes_(name_length) uint8_t* name, uint32_t name_length);
+
+_Success_(return >= 0) static int32_t _ebpf_process_get_account_domain(
+    _In_ process_md_t* process_md, _Out_writes_bytes_(domain_length) uint8_t* domain, uint32_t domain_length);
+
+static const void* _ebpf_process_helper_functions[] = {
+    (void*)&_ebpf_process_get_image_path,
+    (void*)&_ebpf_process_get_account_name,
+    (void*)&_ebpf_process_get_account_domain,
+};
 
 static ebpf_helper_function_addresses_t _ebpf_process_helper_function_address_table = {
     .header = {EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION, EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_SIZE},
@@ -234,6 +244,8 @@ typedef struct _process_notify_context
     PPS_CREATE_NOTIFY_INFO create_info;
     UNICODE_STRING command_line;
     UNICODE_STRING image_file_name;
+    UNICODE_STRING account_name;
+    UNICODE_STRING account_domain;
 } process_notify_context_t;
 
 static ebpf_result_t
@@ -260,11 +272,12 @@ _ebpf_process_context_create(
     }
 
     if (data_in == NULL ||
-        data_size_in < ((size_t)input_context->command_line.Length + (size_t)input_context->image_file_name.Length)) {
+        data_size_in < ((size_t)input_context->command_line.Length + (size_t)input_context->image_file_name.Length +
+                        (size_t)input_context->account_name.Length + (size_t)input_context->account_domain.Length)) {
         EBPF_EXT_LOG_MESSAGE(
             EBPF_EXT_TRACELOG_LEVEL_ERROR,
             EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
-            "Insufficient data for command_line and image_file_name");
+            "Insufficient data for variable-length fields");
         result = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }
@@ -331,7 +344,53 @@ _ebpf_process_context_create(
         process_context->image_file_name.MaximumLength = 0;
     }
 
-    // Set command_start and command_end to point to the copied command_line buffer
+    // Deep copy account_name buffer from data_in if present
+    if (input_context->account_name.Length > 0) {
+        process_context->account_name.Buffer = (PWSTR)ExAllocatePoolUninitialized(
+            NonPagedPoolNx, input_context->account_name.Length, EBPF_EXTENSION_POOL_TAG);
+        if (process_context->account_name.Buffer == NULL) {
+            EBPF_EXT_LOG_MESSAGE(
+                EBPF_EXT_TRACELOG_LEVEL_ERROR,
+                EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
+                "Failed to allocate account_name buffer");
+            result = EBPF_NO_MEMORY;
+            goto Exit;
+        }
+        memcpy(process_context->account_name.Buffer, data_ptr, input_context->account_name.Length);
+        process_context->account_name.Length = input_context->account_name.Length;
+        process_context->account_name.MaximumLength = input_context->account_name.MaximumLength;
+
+        data_ptr += input_context->account_name.Length;
+    } else {
+        process_context->account_name.Buffer = NULL;
+        process_context->account_name.Length = 0;
+        process_context->account_name.MaximumLength = 0;
+    }
+
+    // Deep copy account_domain buffer from data_in if present
+    if (input_context->account_domain.Length > 0) {
+        process_context->account_domain.Buffer = (PWSTR)ExAllocatePoolUninitialized(
+            NonPagedPoolNx, input_context->account_domain.Length, EBPF_EXTENSION_POOL_TAG);
+        if (process_context->account_domain.Buffer == NULL) {
+            EBPF_EXT_LOG_MESSAGE(
+                EBPF_EXT_TRACELOG_LEVEL_ERROR,
+                EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
+                "Failed to allocate account_domain buffer");
+            result = EBPF_NO_MEMORY;
+            goto Exit;
+        }
+        memcpy(process_context->account_domain.Buffer, data_ptr, input_context->account_domain.Length);
+        process_context->account_domain.Length = input_context->account_domain.Length;
+        process_context->account_domain.MaximumLength = input_context->account_domain.MaximumLength;
+
+        data_ptr += input_context->account_domain.Length;
+    } else {
+        process_context->account_domain.Buffer = NULL;
+        process_context->account_domain.Length = 0;
+        process_context->account_domain.MaximumLength = 0;
+    }
+
+    // Set command_startand command_end to point to the copied command_line buffer
     process_context->process_md.command_start = (uint8_t*)process_context->command_line.Buffer;
     process_context->process_md.command_end =
         (uint8_t*)process_context->command_line.Buffer + process_context->command_line.Length;
@@ -347,6 +406,12 @@ Exit:
         }
         if (process_context->image_file_name.Buffer != NULL) {
             ExFreePool(process_context->image_file_name.Buffer);
+        }
+        if (process_context->account_name.Buffer != NULL) {
+            ExFreePool(process_context->account_name.Buffer);
+        }
+        if (process_context->account_domain.Buffer != NULL) {
+            ExFreePool(process_context->account_domain.Buffer);
         }
         ExFreePool(process_context);
         process_context = NULL;
@@ -383,6 +448,8 @@ _ebpf_process_context_destroy(
         // Zero out buffers.
         process_context_out->command_line.Buffer = 0;
         process_context_out->image_file_name.Buffer = 0;
+        process_context_out->account_name.Buffer = 0;
+        process_context_out->account_domain.Buffer = 0;
         process_context_out->process_md.command_start = 0;
         process_context_out->process_md.command_end = 0;
         *context_size_out = sizeof(process_notify_context_t);
@@ -390,8 +457,9 @@ _ebpf_process_context_destroy(
         *context_size_out = 0;
     }
 
-    // Pack command_line and image_file_name into data_out, mirroring data_in structure
-    total_data_size = (size_t)process_context->command_line.Length + (size_t)process_context->image_file_name.Length;
+    // Pack variable-length fields into data_out, mirroring data_in structure
+    total_data_size = (size_t)process_context->command_line.Length + (size_t)process_context->image_file_name.Length +
+                      (size_t)process_context->account_name.Length + (size_t)process_context->account_domain.Length;
     if (data_out != NULL && *data_size_out >= total_data_size) {
         uint8_t* data_ptr = data_out;
 
@@ -407,6 +475,18 @@ _ebpf_process_context_destroy(
             data_ptr += process_context->image_file_name.Length;
         }
 
+        // Copy account_name buffer
+        if (process_context->account_name.Length > 0 && process_context->account_name.Buffer != NULL) {
+            memcpy(data_ptr, process_context->account_name.Buffer, process_context->account_name.Length);
+            data_ptr += process_context->account_name.Length;
+        }
+
+        // Copy account_domain buffer
+        if (process_context->account_domain.Length > 0 && process_context->account_domain.Buffer != NULL) {
+            memcpy(data_ptr, process_context->account_domain.Buffer, process_context->account_domain.Length);
+            data_ptr += process_context->account_domain.Length;
+        }
+
         *data_size_out = total_data_size;
     } else {
         *data_size_out = 0;
@@ -419,7 +499,12 @@ _ebpf_process_context_destroy(
     if (process_context->image_file_name.Buffer != NULL) {
         ExFreePool(process_context->image_file_name.Buffer);
     }
-
+    if (process_context->account_name.Buffer != NULL) {
+        ExFreePool(process_context->account_name.Buffer);
+    }
+    if (process_context->account_domain.Buffer != NULL) {
+        ExFreePool(process_context->account_domain.Buffer);
+    }
     ExFreePool(process_context);
 
 Exit:
@@ -431,7 +516,13 @@ _ebpf_process_create_process_notify_routine_ex(
     _Inout_ PEPROCESS process, _In_ HANDLE process_id, _Inout_opt_ PPS_CREATE_NOTIFY_INFO create_info)
 {
     process_notify_context_t process_notify_context = {
-        .process_md = {0}, .process = process, .create_info = create_info, .command_line = {0}, .image_file_name = {0}};
+        .process_md = {0},
+        .process = process,
+        .create_info = create_info,
+        .command_line = {0},
+        .image_file_name = {0},
+        .account_name = {0},
+        .account_domain = {0}};
 
     EBPF_EXT_LOG_ENTRY();
     ebpf_extension_hook_client_t* client_context;
@@ -467,12 +558,67 @@ _ebpf_process_create_process_notify_routine_ex(
                             process_notify_context.process_md.token_sid_size = sid_length;
                             memcpy(process_notify_context.process_md.token_sid, token_user->User.Sid, sid_length);
                         }
+
+                        // Resolve SID to account name and domain.
+                        {
+                            ULONG name_size = 0;
+                            ULONG domain_size = 0;
+                            SID_NAME_USE name_use;
+
+                            // First call with NULL buffers to get required sizes.
+#pragma warning(disable : 6387) // NameBuffer can be NULL for the sizing call per API contract.
+                            NTSTATUS lookup_status = SecLookupAccountSid(
+                                token_user->User.Sid, &name_size, NULL, &domain_size, NULL, &name_use);
+                            if (lookup_status == STATUS_BUFFER_TOO_SMALL) {
+                                if (name_size > 0) {
+                                    process_notify_context.account_name.Buffer = (PWSTR)ExAllocatePoolUninitialized(
+                                        NonPagedPoolNx, name_size, EBPF_EXTENSION_POOL_TAG);
+                                    if (process_notify_context.account_name.Buffer != NULL) {
+                                        process_notify_context.account_name.MaximumLength = (USHORT)name_size;
+                                    }
+                                }
+                                if (domain_size > 0) {
+                                    process_notify_context.account_domain.Buffer = (PWSTR)ExAllocatePoolUninitialized(
+                                        NonPagedPoolNx, domain_size, EBPF_EXTENSION_POOL_TAG);
+                                    if (process_notify_context.account_domain.Buffer != NULL) {
+                                        process_notify_context.account_domain.MaximumLength = (USHORT)domain_size;
+                                    }
+                                }
+
+                                if ((name_size == 0 || process_notify_context.account_name.Buffer != NULL) &&
+                                    (domain_size == 0 || process_notify_context.account_domain.Buffer != NULL)) {
+                                    lookup_status = SecLookupAccountSid(
+                                        token_user->User.Sid,
+                                        &name_size,
+                                        name_size > 0 ? &process_notify_context.account_name : NULL,
+                                        &domain_size,
+                                        domain_size > 0 ? &process_notify_context.account_domain : NULL,
+                                        &name_use);
+                                    if (NT_SUCCESS(lookup_status)) {
+                                        process_notify_context.account_name.Length = (USHORT)name_size;
+                                        process_notify_context.account_domain.Length = (USHORT)domain_size;
+                                    } else {
+                                        // Lookup failed; free buffers.
+                                        if (process_notify_context.account_name.Buffer != NULL) {
+                                            ExFreePool(process_notify_context.account_name.Buffer);
+                                            process_notify_context.account_name.Buffer = NULL;
+                                        }
+                                        if (process_notify_context.account_domain.Buffer != NULL) {
+                                            ExFreePool(process_notify_context.account_domain.Buffer);
+                                            process_notify_context.account_domain.Buffer = NULL;
+                                        }
+                                    }
+                                }
+                            }
+#pragma warning(pop)
+                        }
                     }
                     ExFreePool(token_user);
                 }
                 PsDereferencePrimaryToken(token);
             }
         }
+
     } else {
         process_notify_context.process_md.operation = PROCESS_OPERATION_DELETE;
         process_notify_context.process_md.exit_time = PsGetProcessExitTime().QuadPart;
@@ -510,6 +656,12 @@ _ebpf_process_create_process_notify_routine_ex(
             ebpf_extension_hook_get_next_attached_client(_ebpf_process_hook_provider_context, client_context);
     }
 
+    if (process_notify_context.account_name.Buffer != NULL) {
+        ExFreePool(process_notify_context.account_name.Buffer);
+    }
+    if (process_notify_context.account_domain.Buffer != NULL) {
+        ExFreePool(process_notify_context.account_domain.Buffer);
+    }
     EBPF_EXT_LOG_EXIT();
 }
 
@@ -527,6 +679,43 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_image_path(
             memcpy(
                 path, process_notify_context->image_file_name.Buffer, process_notify_context->image_file_name.Length);
             result = process_notify_context->image_file_name.Length;
+        }
+    }
+    return result;
+}
+
+_Success_(return >= 0) static int32_t _ebpf_process_get_account_name(
+    _In_ process_md_t* process_md, _Out_writes_bytes_(name_length) uint8_t* name, uint32_t name_length)
+{
+    process_notify_context_t* process_notify_context =
+        CONTAINING_RECORD(process_md, process_notify_context_t, process_md);
+    int32_t result = 0;
+    if (process_notify_context->account_name.Length > name_length) {
+        return -EINVAL;
+    }
+    if (process_notify_context->account_name.Buffer != NULL) {
+        if (name_length >= process_notify_context->account_name.Length) {
+            memcpy(name, process_notify_context->account_name.Buffer, process_notify_context->account_name.Length);
+            result = process_notify_context->account_name.Length;
+        }
+    }
+    return result;
+}
+
+_Success_(return >= 0) static int32_t _ebpf_process_get_account_domain(
+    _In_ process_md_t* process_md, _Out_writes_bytes_(domain_length) uint8_t* domain, uint32_t domain_length)
+{
+    process_notify_context_t* process_notify_context =
+        CONTAINING_RECORD(process_md, process_notify_context_t, process_md);
+    int32_t result = 0;
+    if (process_notify_context->account_domain.Length > domain_length) {
+        return -EINVAL;
+    }
+    if (process_notify_context->account_domain.Buffer != NULL) {
+        if (domain_length >= process_notify_context->account_domain.Length) {
+            memcpy(
+                domain, process_notify_context->account_domain.Buffer, process_notify_context->account_domain.Length);
+            result = process_notify_context->account_domain.Length;
         }
     }
     return result;

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -304,7 +304,7 @@ _ebpf_process_context_create(
     // Deep copy command_line buffer from data_in if present
     if (input_context->command_line.Length > 0) {
         process_context->command_line.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-            NonPagedPoolNx, input_context->command_line.Length, EBPF_EXTENSION_POOL_TAG);
+            NonPagedPoolNx, input_context->command_line.MaximumLength, EBPF_EXTENSION_POOL_TAG);
         if (process_context->command_line.Buffer == NULL) {
             EBPF_EXT_LOG_MESSAGE(
                 EBPF_EXT_TRACELOG_LEVEL_ERROR,
@@ -327,7 +327,7 @@ _ebpf_process_context_create(
     // Deep copy image_file_name buffer from data_in if present
     if (input_context->image_file_name.Length > 0) {
         process_context->image_file_name.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-            NonPagedPoolNx, input_context->image_file_name.Length, EBPF_EXTENSION_POOL_TAG);
+            NonPagedPoolNx, input_context->image_file_name.MaximumLength, EBPF_EXTENSION_POOL_TAG);
         if (process_context->image_file_name.Buffer == NULL) {
             EBPF_EXT_LOG_MESSAGE(
                 EBPF_EXT_TRACELOG_LEVEL_ERROR,
@@ -350,7 +350,7 @@ _ebpf_process_context_create(
     // Deep copy account_name buffer from data_in if present
     if (input_context->account_name.Length > 0) {
         process_context->account_name.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-            NonPagedPoolNx, input_context->account_name.Length, EBPF_EXTENSION_POOL_TAG);
+            NonPagedPoolNx, input_context->account_name.MaximumLength, EBPF_EXTENSION_POOL_TAG);
         if (process_context->account_name.Buffer == NULL) {
             EBPF_EXT_LOG_MESSAGE(
                 EBPF_EXT_TRACELOG_LEVEL_ERROR,
@@ -373,7 +373,7 @@ _ebpf_process_context_create(
     // Deep copy account_domain buffer from data_in if present
     if (input_context->account_domain.Length > 0) {
         process_context->account_domain.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-            NonPagedPoolNx, input_context->account_domain.Length, EBPF_EXTENSION_POOL_TAG);
+            NonPagedPoolNx, input_context->account_domain.MaximumLength, EBPF_EXTENSION_POOL_TAG);
         if (process_context->account_domain.Buffer == NULL) {
             EBPF_EXT_LOG_MESSAGE(
                 EBPF_EXT_TRACELOG_LEVEL_ERROR,

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -12,7 +12,7 @@
 
 #include <errno.h>
 
-// Maximum number of WCHARs for inline account name/domain buffers on the stack.
+// Maximum number of bytes for inline account name/domain buffers on the stack.
 #define ACCOUNT_STRING_INLINE_CHARS 80
 
 // Define the pool tag for this extension
@@ -249,6 +249,7 @@ typedef struct _process_notify_context
     UNICODE_STRING image_file_name;
     UNICODE_STRING account_name;
     UNICODE_STRING account_domain;
+    BOOLEAN account_lookup_done;
 } process_notify_context_t;
 
 static ebpf_result_t
@@ -285,6 +286,19 @@ _ebpf_process_context_create(
         goto Exit;
     }
 
+    // Validate that Length does not exceed MaximumLength for each UNICODE_STRING.
+    if (input_context->command_line.Length > input_context->command_line.MaximumLength ||
+        input_context->image_file_name.Length > input_context->image_file_name.MaximumLength ||
+        input_context->account_name.Length > input_context->account_name.MaximumLength ||
+        input_context->account_domain.Length > input_context->account_domain.MaximumLength) {
+        EBPF_EXT_LOG_MESSAGE(
+            EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
+            "UNICODE_STRING Length exceeds MaximumLength");
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
     process_context = (process_notify_context_t*)ExAllocatePoolUninitialized(
         NonPagedPoolNx, sizeof(process_notify_context_t), EBPF_EXTENSION_POOL_TAG);
     EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
@@ -297,6 +311,8 @@ _ebpf_process_context_create(
     // These are kernel pointers that must be NULL when creating context from user mode.
     process_context->process = NULL;
     process_context->create_info = NULL;
+    // Test contexts have account data provided in data_in, so skip lazy lookup.
+    process_context->account_lookup_done = TRUE;
 
     // Parse data_in buffer: [command_line data][image_file_name data]
     // The lengths are specified in the UNICODE_STRING structures from the context
@@ -518,9 +534,8 @@ void
 _ebpf_process_create_process_notify_routine_ex(
     _Inout_ PEPROCESS process, _In_ HANDLE process_id, _Inout_opt_ PPS_CREATE_NOTIFY_INFO create_info)
 {
-    // Inline buffers for account name/domain to avoid pool allocation in the common case.
-    WCHAR account_name_inline[ACCOUNT_STRING_INLINE_CHARS] = {0};
-    WCHAR account_domain_inline[ACCOUNT_STRING_INLINE_CHARS] = {0};
+    WCHAR account_name_stack_buffer[ACCOUNT_STRING_INLINE_CHARS / sizeof(WCHAR)];
+    WCHAR account_domain_stack_buffer[ACCOUNT_STRING_INLINE_CHARS / sizeof(WCHAR)];
 
     process_notify_context_t process_notify_context = {
         .process_md = {0},
@@ -529,7 +544,14 @@ _ebpf_process_create_process_notify_routine_ex(
         .command_line = {0},
         .image_file_name = {0},
         .account_name = {0},
-        .account_domain = {0}};
+        .account_domain = {0},
+        .account_lookup_done = FALSE};
+
+    // Point account UNICODE_STRINGs at stack-allocated inline buffers.
+    process_notify_context.account_name.Buffer = account_name_stack_buffer;
+    process_notify_context.account_name.MaximumLength = ACCOUNT_STRING_INLINE_CHARS;
+    process_notify_context.account_domain.Buffer = account_domain_stack_buffer;
+    process_notify_context.account_domain.MaximumLength = ACCOUNT_STRING_INLINE_CHARS;
 
     EBPF_EXT_LOG_ENTRY();
     ebpf_extension_hook_client_t* client_context;
@@ -564,68 +586,6 @@ _ebpf_process_create_process_notify_routine_ex(
                         if (sid_length <= TOKEN_SID_MAX_SIZE) {
                             process_notify_context.process_md.token_sid_size = sid_length;
                             memcpy(process_notify_context.process_md.token_sid, token_user->User.Sid, sid_length);
-                        }
-
-                        // Resolve SID to account name and domain.
-                        {
-                            ULONG name_size = 0;
-                            ULONG domain_size = 0;
-                            SID_NAME_USE name_use;
-
-                            // First call with NULL buffers to get required sizes.
-#pragma warning(push)
-#pragma warning(disable : 6387) // NameBuffer can be NULL for the sizing call per API contract.
-                            NTSTATUS lookup_status = SecLookupAccountSid(
-                                token_user->User.Sid, &name_size, NULL, &domain_size, NULL, &name_use);
-                            if (lookup_status == STATUS_BUFFER_TOO_SMALL) {
-                                // Use inline stack buffers if they fit, otherwise pool-allocate.
-                                if (name_size <= sizeof(account_name_inline)) {
-                                    process_notify_context.account_name.Buffer = account_name_inline;
-                                } else {
-                                    process_notify_context.account_name.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-                                        NonPagedPoolNx, name_size, EBPF_EXTENSION_POOL_TAG);
-                                }
-                                if (process_notify_context.account_name.Buffer != NULL) {
-                                    process_notify_context.account_name.MaximumLength = (USHORT)name_size;
-                                }
-
-                                if (domain_size <= sizeof(account_domain_inline)) {
-                                    process_notify_context.account_domain.Buffer = account_domain_inline;
-                                } else {
-                                    process_notify_context.account_domain.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-                                        NonPagedPoolNx, domain_size, EBPF_EXTENSION_POOL_TAG);
-                                }
-                                if (process_notify_context.account_domain.Buffer != NULL) {
-                                    process_notify_context.account_domain.MaximumLength = (USHORT)domain_size;
-                                }
-
-                                if (process_notify_context.account_name.Buffer != NULL &&
-                                    process_notify_context.account_domain.Buffer != NULL) {
-                                    lookup_status = SecLookupAccountSid(
-                                        token_user->User.Sid,
-                                        &name_size,
-                                        &process_notify_context.account_name,
-                                        &domain_size,
-                                        &process_notify_context.account_domain,
-                                        &name_use);
-                                    if (!NT_SUCCESS(lookup_status)) {
-                                        // Lookup failed; free pool-allocated buffers and reset lengths.
-                                        if (process_notify_context.account_name.Buffer != account_name_inline) {
-                                            ExFreePool(process_notify_context.account_name.Buffer);
-                                        }
-                                        process_notify_context.account_name.Buffer = NULL;
-                                        process_notify_context.account_name.Length = 0;
-                                        process_notify_context.account_name.MaximumLength = 0;
-                                        if (process_notify_context.account_domain.Buffer != account_domain_inline) {
-                                            ExFreePool(process_notify_context.account_domain.Buffer);
-                                        }
-                                        process_notify_context.account_domain.Buffer = NULL;
-                                        process_notify_context.account_domain.Length = 0;
-                                        process_notify_context.account_domain.MaximumLength = 0;
-                                    }
-                                }
-                            }
-#pragma warning(pop)
                         }
                     }
                     ExFreePool(token_user);
@@ -672,11 +632,11 @@ _ebpf_process_create_process_notify_routine_ex(
     }
 
     if (process_notify_context.account_name.Buffer != NULL &&
-        process_notify_context.account_name.Buffer != account_name_inline) {
+        process_notify_context.account_name.Buffer != account_name_stack_buffer) {
         ExFreePool(process_notify_context.account_name.Buffer);
     }
     if (process_notify_context.account_domain.Buffer != NULL &&
-        process_notify_context.account_domain.Buffer != account_domain_inline) {
+        process_notify_context.account_domain.Buffer != account_domain_stack_buffer) {
         ExFreePool(process_notify_context.account_domain.Buffer);
     }
     EBPF_EXT_LOG_EXIT();
@@ -701,11 +661,119 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_image_path(
     return result;
 }
 
+// Lazily resolve the account name and domain from the process token SID.
+// Called on first invocation of either account helper; results are cached.
+static void
+_ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_context)
+{
+    if (process_notify_context->account_lookup_done) {
+        return;
+    }
+    process_notify_context->account_lookup_done = TRUE;
+
+    if (process_notify_context->process == NULL) {
+        return;
+    }
+
+    PACCESS_TOKEN token = PsReferencePrimaryToken(process_notify_context->process);
+    if (token == NULL) {
+        return;
+    }
+
+    PTOKEN_USER token_user = NULL;
+    NTSTATUS sid_status = SeQueryInformationToken(token, TokenUser, (PVOID*)&token_user);
+    if (!NT_SUCCESS(sid_status) || token_user == NULL) {
+        PsDereferencePrimaryToken(token);
+        return;
+    }
+
+    if (!RtlValidSid(token_user->User.Sid)) {
+        ExFreePool(token_user);
+        PsDereferencePrimaryToken(token);
+        return;
+    }
+
+    ULONG name_size = process_notify_context->account_name.MaximumLength;
+    ULONG domain_size = process_notify_context->account_domain.MaximumLength;
+    SID_NAME_USE name_use;
+
+    // Try the lookup optimistically with the existing (stack) buffers.
+    NTSTATUS lookup_status = SecLookupAccountSid(
+        token_user->User.Sid,
+        &name_size,
+        &process_notify_context->account_name,
+        &domain_size,
+        &process_notify_context->account_domain,
+        &name_use);
+
+    if (lookup_status == STATUS_BUFFER_TOO_SMALL) {
+        // Stack buffers too small — heap-allocate with the returned sizes and retry.
+        BOOLEAN name_heap_allocated = FALSE;
+        BOOLEAN domain_heap_allocated = FALSE;
+
+        if (name_size > process_notify_context->account_name.MaximumLength) {
+            PWSTR new_buf = (PWSTR)ExAllocatePoolUninitialized(NonPagedPoolNx, name_size, EBPF_EXTENSION_POOL_TAG);
+            if (new_buf != NULL) {
+                process_notify_context->account_name.Buffer = new_buf;
+                process_notify_context->account_name.MaximumLength = (USHORT)name_size;
+                name_heap_allocated = TRUE;
+            } else {
+                process_notify_context->account_name.Buffer = NULL;
+            }
+        }
+
+        if (domain_size > process_notify_context->account_domain.MaximumLength) {
+            PWSTR new_buf = (PWSTR)ExAllocatePoolUninitialized(NonPagedPoolNx, domain_size, EBPF_EXTENSION_POOL_TAG);
+            if (new_buf != NULL) {
+                process_notify_context->account_domain.Buffer = new_buf;
+                process_notify_context->account_domain.MaximumLength = (USHORT)domain_size;
+                domain_heap_allocated = TRUE;
+            } else {
+                process_notify_context->account_domain.Buffer = NULL;
+            }
+        }
+
+        if (process_notify_context->account_name.Buffer != NULL &&
+            process_notify_context->account_domain.Buffer != NULL) {
+            lookup_status = SecLookupAccountSid(
+                token_user->User.Sid,
+                &name_size,
+                &process_notify_context->account_name,
+                &domain_size,
+                &process_notify_context->account_domain,
+                &name_use);
+        }
+
+        if (!NT_SUCCESS(lookup_status)) {
+            if (name_heap_allocated) {
+                ExFreePool(process_notify_context->account_name.Buffer);
+            }
+            process_notify_context->account_name.Buffer = NULL;
+            process_notify_context->account_name.Length = 0;
+            process_notify_context->account_name.MaximumLength = 0;
+            if (domain_heap_allocated) {
+                ExFreePool(process_notify_context->account_domain.Buffer);
+            }
+            process_notify_context->account_domain.Buffer = NULL;
+            process_notify_context->account_domain.Length = 0;
+            process_notify_context->account_domain.MaximumLength = 0;
+        }
+    } else if (!NT_SUCCESS(lookup_status)) {
+        // Lookup failed for a reason other than buffer size — clear results.
+        process_notify_context->account_name.Length = 0;
+        process_notify_context->account_domain.Length = 0;
+    }
+
+    ExFreePool(token_user);
+    PsDereferencePrimaryToken(token);
+}
+
 _Success_(return >= 0) static int32_t _ebpf_process_get_account_name(
     _In_ process_md_t* process_md, _Out_writes_bytes_(name_length) uint8_t* name, uint32_t name_length)
 {
     process_notify_context_t* process_notify_context =
         CONTAINING_RECORD(process_md, process_notify_context_t, process_md);
+    _ebpf_process_resolve_account(process_notify_context);
     int32_t result = 0;
     if (process_notify_context->account_name.Length > name_length) {
         return -EINVAL;
@@ -724,6 +792,7 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_account_domain(
 {
     process_notify_context_t* process_notify_context =
         CONTAINING_RECORD(process_md, process_notify_context_t, process_md);
+    _ebpf_process_resolve_account(process_notify_context);
     int32_t result = 0;
     if (process_notify_context->account_domain.Length > domain_length) {
         return -EINVAL;

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -390,7 +390,7 @@ _ebpf_process_context_create(
         process_context->account_domain.MaximumLength = 0;
     }
 
-    // Set command_startand command_end to point to the copied command_line buffer
+    // Set command_start and command_end to point to the copied command_line buffer
     process_context->process_md.command_start = (uint8_t*)process_context->command_line.Buffer;
     process_context->process_md.command_end =
         (uint8_t*)process_context->command_line.Buffer + process_context->command_line.Length;
@@ -566,6 +566,7 @@ _ebpf_process_create_process_notify_routine_ex(
                             SID_NAME_USE name_use;
 
                             // First call with NULL buffers to get required sizes.
+#pragma warning(push)
 #pragma warning(disable : 6387) // NameBuffer can be NULL for the sizing call per API contract.
                             NTSTATUS lookup_status = SecLookupAccountSid(
                                 token_user->User.Sid, &name_size, NULL, &domain_size, NULL, &name_use);
@@ -594,19 +595,20 @@ _ebpf_process_create_process_notify_routine_ex(
                                         &domain_size,
                                         domain_size > 0 ? &process_notify_context.account_domain : NULL,
                                         &name_use);
-                                    if (NT_SUCCESS(lookup_status)) {
-                                        process_notify_context.account_name.Length = (USHORT)name_size;
-                                        process_notify_context.account_domain.Length = (USHORT)domain_size;
-                                    } else {
-                                        // Lookup failed; free buffers.
+                                    if (!NT_SUCCESS(lookup_status)) {
+                                        // Lookup failed; free buffers and reset lengths.
                                         if (process_notify_context.account_name.Buffer != NULL) {
                                             ExFreePool(process_notify_context.account_name.Buffer);
                                             process_notify_context.account_name.Buffer = NULL;
                                         }
+                                        process_notify_context.account_name.Length = 0;
+                                        process_notify_context.account_name.MaximumLength = 0;
                                         if (process_notify_context.account_domain.Buffer != NULL) {
                                             ExFreePool(process_notify_context.account_domain.Buffer);
                                             process_notify_context.account_domain.Buffer = NULL;
                                         }
+                                        process_notify_context.account_domain.Length = 0;
+                                        process_notify_context.account_domain.MaximumLength = 0;
                                     }
                                 }
                             }

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -595,18 +595,13 @@ _ebpf_process_create_process_notify_routine_ex(
             if (token != NULL) {
                 PTOKEN_USER token_user = NULL;
                 NTSTATUS sid_status = SeQueryInformationToken(token, TokenUser, (PVOID*)&token_user);
-                if (NT_SUCCESS(sid_status) && token_user != NULL) {
-                    if (RtlValidSid(token_user->User.Sid)) {
-                        ULONG sid_length = RtlLengthSid(token_user->User.Sid);
-                        if (sid_length <= TOKEN_SID_MAX_SIZE) {
-                            NTSTATUS copy_status = RtlCopySid(
-                                TOKEN_SID_MAX_SIZE,
-                                (PSID)process_notify_context.process_md.token_sid,
-                                token_user->User.Sid);
-                            if (NT_SUCCESS(copy_status)) {
-                                process_notify_context.process_md.token_sid_size = sid_length;
-                            }
-                        }
+                if (NT_SUCCESS(sid_status) && token_user != NULL && RtlValidSid(token_user->User.Sid)) {
+                    ULONG sid_length = RtlLengthSid(token_user->User.Sid);
+                    if (sid_length <= TOKEN_SID_MAX_SIZE && NT_SUCCESS(RtlCopySid(
+                                                                TOKEN_SID_MAX_SIZE,
+                                                                (PSID)process_notify_context.process_md.token_sid,
+                                                                token_user->User.Sid))) {
+                        process_notify_context.process_md.token_sid_size = sid_length;
                     }
                     ExFreePool(token_user);
                 }

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -12,6 +12,9 @@
 
 #include <errno.h>
 
+// Maximum number of WCHARs for inline account name/domain buffers on the stack.
+#define ACCOUNT_STRING_INLINE_CHARS 80
+
 // Define the pool tag for this extension
 ULONG EBPF_EXTENSION_POOL_TAG = EBPF_NTOS_EXTENSION_POOL_TAG;
 
@@ -515,6 +518,10 @@ void
 _ebpf_process_create_process_notify_routine_ex(
     _Inout_ PEPROCESS process, _In_ HANDLE process_id, _Inout_opt_ PPS_CREATE_NOTIFY_INFO create_info)
 {
+    // Inline buffers for account name/domain to avoid pool allocation in the common case.
+    WCHAR account_name_inline[ACCOUNT_STRING_INLINE_CHARS] = {0};
+    WCHAR account_domain_inline[ACCOUNT_STRING_INLINE_CHARS] = {0};
+
     process_notify_context_t process_notify_context = {
         .process_md = {0},
         .process = process,
@@ -571,42 +578,48 @@ _ebpf_process_create_process_notify_routine_ex(
                             NTSTATUS lookup_status = SecLookupAccountSid(
                                 token_user->User.Sid, &name_size, NULL, &domain_size, NULL, &name_use);
                             if (lookup_status == STATUS_BUFFER_TOO_SMALL) {
-                                if (name_size > 0) {
+                                // Use inline stack buffers if they fit, otherwise pool-allocate.
+                                if (name_size <= sizeof(account_name_inline)) {
+                                    process_notify_context.account_name.Buffer = account_name_inline;
+                                } else {
                                     process_notify_context.account_name.Buffer = (PWSTR)ExAllocatePoolUninitialized(
                                         NonPagedPoolNx, name_size, EBPF_EXTENSION_POOL_TAG);
-                                    if (process_notify_context.account_name.Buffer != NULL) {
-                                        process_notify_context.account_name.MaximumLength = (USHORT)name_size;
-                                    }
                                 }
-                                if (domain_size > 0) {
-                                    process_notify_context.account_domain.Buffer = (PWSTR)ExAllocatePoolUninitialized(
-                                        NonPagedPoolNx, domain_size, EBPF_EXTENSION_POOL_TAG);
-                                    if (process_notify_context.account_domain.Buffer != NULL) {
-                                        process_notify_context.account_domain.MaximumLength = (USHORT)domain_size;
-                                    }
+                                if (process_notify_context.account_name.Buffer != NULL) {
+                                    process_notify_context.account_name.MaximumLength = (USHORT)name_size;
                                 }
 
-                                if ((name_size == 0 || process_notify_context.account_name.Buffer != NULL) &&
-                                    (domain_size == 0 || process_notify_context.account_domain.Buffer != NULL)) {
+                                if (domain_size <= sizeof(account_domain_inline)) {
+                                    process_notify_context.account_domain.Buffer = account_domain_inline;
+                                } else {
+                                    process_notify_context.account_domain.Buffer = (PWSTR)ExAllocatePoolUninitialized(
+                                        NonPagedPoolNx, domain_size, EBPF_EXTENSION_POOL_TAG);
+                                }
+                                if (process_notify_context.account_domain.Buffer != NULL) {
+                                    process_notify_context.account_domain.MaximumLength = (USHORT)domain_size;
+                                }
+
+                                if (process_notify_context.account_name.Buffer != NULL &&
+                                    process_notify_context.account_domain.Buffer != NULL) {
                                     lookup_status = SecLookupAccountSid(
                                         token_user->User.Sid,
                                         &name_size,
-                                        name_size > 0 ? &process_notify_context.account_name : NULL,
+                                        &process_notify_context.account_name,
                                         &domain_size,
-                                        domain_size > 0 ? &process_notify_context.account_domain : NULL,
+                                        &process_notify_context.account_domain,
                                         &name_use);
                                     if (!NT_SUCCESS(lookup_status)) {
-                                        // Lookup failed; free buffers and reset lengths.
-                                        if (process_notify_context.account_name.Buffer != NULL) {
+                                        // Lookup failed; free pool-allocated buffers and reset lengths.
+                                        if (process_notify_context.account_name.Buffer != account_name_inline) {
                                             ExFreePool(process_notify_context.account_name.Buffer);
-                                            process_notify_context.account_name.Buffer = NULL;
                                         }
+                                        process_notify_context.account_name.Buffer = NULL;
                                         process_notify_context.account_name.Length = 0;
                                         process_notify_context.account_name.MaximumLength = 0;
-                                        if (process_notify_context.account_domain.Buffer != NULL) {
+                                        if (process_notify_context.account_domain.Buffer != account_domain_inline) {
                                             ExFreePool(process_notify_context.account_domain.Buffer);
-                                            process_notify_context.account_domain.Buffer = NULL;
                                         }
+                                        process_notify_context.account_domain.Buffer = NULL;
                                         process_notify_context.account_domain.Length = 0;
                                         process_notify_context.account_domain.MaximumLength = 0;
                                     }
@@ -658,10 +671,12 @@ _ebpf_process_create_process_notify_routine_ex(
             ebpf_extension_hook_get_next_attached_client(_ebpf_process_hook_provider_context, client_context);
     }
 
-    if (process_notify_context.account_name.Buffer != NULL) {
+    if (process_notify_context.account_name.Buffer != NULL &&
+        process_notify_context.account_name.Buffer != account_name_inline) {
         ExFreePool(process_notify_context.account_name.Buffer);
     }
-    if (process_notify_context.account_domain.Buffer != NULL) {
+    if (process_notify_context.account_domain.Buffer != NULL &&
+        process_notify_context.account_domain.Buffer != account_domain_inline) {
         ExFreePool(process_notify_context.account_domain.Buffer);
     }
     EBPF_EXT_LOG_EXIT();

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -9,11 +9,12 @@
 #include "ebpf_ntos_hooks.h"
 #include "ntos_ebpf_ext_process.h"
 #include "ntos_ebpf_ext_program_info.h"
+#include "shared_context.h"
 
 #include <errno.h>
 
 // Maximum number of bytes for inline account name/domain buffers on the stack.
-#define ACCOUNT_STRING_INLINE_CHARS 80
+#define ACCOUNT_STRING_INLINE_BYTES 80
 
 // Define the pool tag for this extension
 ULONG EBPF_EXTENSION_POOL_TAG = EBPF_NTOS_EXTENSION_POOL_TAG;
@@ -543,8 +544,8 @@ void
 _ebpf_process_create_process_notify_routine_ex(
     _Inout_ PEPROCESS process, _In_ HANDLE process_id, _Inout_opt_ PPS_CREATE_NOTIFY_INFO create_info)
 {
-    WCHAR account_name_stack_buffer[ACCOUNT_STRING_INLINE_CHARS / sizeof(WCHAR)];
-    WCHAR account_domain_stack_buffer[ACCOUNT_STRING_INLINE_CHARS / sizeof(WCHAR)];
+    WCHAR account_name_stack_buffer[ACCOUNT_STRING_INLINE_BYTES / sizeof(WCHAR)] = {0};
+    WCHAR account_domain_stack_buffer[ACCOUNT_STRING_INLINE_BYTES / sizeof(WCHAR)] = {0};
 
     process_notify_context_t process_notify_context = {
         .process_md = {0},
@@ -558,9 +559,9 @@ _ebpf_process_create_process_notify_routine_ex(
 
     // Point account UNICODE_STRINGs at stack-allocated inline buffers.
     process_notify_context.account_name.Buffer = account_name_stack_buffer;
-    process_notify_context.account_name.MaximumLength = ACCOUNT_STRING_INLINE_CHARS;
+    process_notify_context.account_name.MaximumLength = ACCOUNT_STRING_INLINE_BYTES;
     process_notify_context.account_domain.Buffer = account_domain_stack_buffer;
-    process_notify_context.account_domain.MaximumLength = ACCOUNT_STRING_INLINE_CHARS;
+    process_notify_context.account_domain.MaximumLength = ACCOUNT_STRING_INLINE_BYTES;
 
     EBPF_EXT_LOG_ENTRY();
     ebpf_extension_hook_client_t* client_context;
@@ -593,8 +594,13 @@ _ebpf_process_create_process_notify_routine_ex(
                     if (RtlValidSid(token_user->User.Sid)) {
                         ULONG sid_length = RtlLengthSid(token_user->User.Sid);
                         if (sid_length <= TOKEN_SID_MAX_SIZE) {
-                            process_notify_context.process_md.token_sid_size = sid_length;
-                            memcpy(process_notify_context.process_md.token_sid, token_user->User.Sid, sid_length);
+                            NTSTATUS copy_status = RtlCopySid(
+                                TOKEN_SID_MAX_SIZE,
+                                (PSID)process_notify_context.process_md.token_sid,
+                                token_user->User.Sid);
+                            if (NT_SUCCESS(copy_status)) {
+                                process_notify_context.process_md.token_sid_size = sid_length;
+                            }
                         }
                     }
                     ExFreePool(token_user);
@@ -672,42 +678,52 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_image_path(
 
 // Lazily resolve the account name and domain from the process token SID.
 // Called on first invocation of either account helper; results are cached.
-static void
+// The process creation notify routine runs at PASSIVE_LEVEL, so PsReferencePrimaryToken is safe to call.
+static NTSTATUS
 _ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_context)
 {
+    NTSTATUS status = STATUS_SUCCESS;
+    PTOKEN_USER token_user = NULL;
+    PACCESS_TOKEN token = NULL;
+    BOOLEAN name_heap_allocated = FALSE;
+    BOOLEAN domain_heap_allocated = FALSE;
+    ULONG name_size = 0;
+    ULONG domain_size = 0;
+    SID_NAME_USE name_use;
+
+    ebpf_assert(KeGetCurrentIrql() == PASSIVE_LEVEL);
+
     if (process_notify_context->account_lookup_done) {
-        return;
+        return STATUS_SUCCESS;
     }
-    process_notify_context->account_lookup_done = TRUE;
 
     if (process_notify_context->process == NULL) {
-        return;
+        status = STATUS_INVALID_PARAMETER;
+        goto Exit;
     }
 
-    PACCESS_TOKEN token = PsReferencePrimaryToken(process_notify_context->process);
+    token = PsReferencePrimaryToken(process_notify_context->process);
+    ebpf_assert(token != NULL);
     if (token == NULL) {
-        return;
+        status = STATUS_UNSUCCESSFUL;
+        goto Exit;
     }
 
-    PTOKEN_USER token_user = NULL;
-    NTSTATUS sid_status = SeQueryInformationToken(token, TokenUser, (PVOID*)&token_user);
-    if (!NT_SUCCESS(sid_status) || token_user == NULL) {
-        PsDereferencePrimaryToken(token);
-        return;
+    status = SeQueryInformationToken(token, TokenUser, (PVOID*)&token_user);
+    if (!NT_SUCCESS(status) || token_user == NULL) {
+        goto Exit;
     }
 
     if (!RtlValidSid(token_user->User.Sid)) {
-        ExFreePool(token_user);
-        PsDereferencePrimaryToken(token);
-        return;
+        status = STATUS_UNSUCCESSFUL;
+        goto Exit;
     }
 
-    ULONG name_size = process_notify_context->account_name.MaximumLength;
-    ULONG domain_size = process_notify_context->account_domain.MaximumLength;
-    SID_NAME_USE name_use;
+    name_size = process_notify_context->account_name.MaximumLength;
+    domain_size = process_notify_context->account_domain.MaximumLength;
 
     // Try the lookup optimistically with the existing (stack) buffers.
-    NTSTATUS lookup_status = SecLookupAccountSid(
+    status = SecLookupAccountSid(
         token_user->User.Sid,
         &name_size,
         &process_notify_context->account_name,
@@ -715,11 +731,8 @@ _ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_c
         &process_notify_context->account_domain,
         &name_use);
 
-    if (lookup_status == STATUS_BUFFER_TOO_SMALL) {
+    if (status == STATUS_BUFFER_TOO_SMALL) {
         // Stack buffers too small — heap-allocate with the returned sizes and retry.
-        BOOLEAN name_heap_allocated = FALSE;
-        BOOLEAN domain_heap_allocated = FALSE;
-
         if (name_size > process_notify_context->account_name.MaximumLength) {
             PWSTR new_buf = (PWSTR)ExAllocatePoolUninitialized(NonPagedPoolNx, name_size, EBPF_EXTENSION_POOL_TAG);
             if (new_buf != NULL) {
@@ -727,7 +740,8 @@ _ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_c
                 process_notify_context->account_name.MaximumLength = (USHORT)name_size;
                 name_heap_allocated = TRUE;
             } else {
-                process_notify_context->account_name.Buffer = NULL;
+                status = STATUS_INSUFFICIENT_RESOURCES;
+                goto Exit;
             }
         }
 
@@ -738,54 +752,72 @@ _ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_c
                 process_notify_context->account_domain.MaximumLength = (USHORT)domain_size;
                 domain_heap_allocated = TRUE;
             } else {
-                process_notify_context->account_domain.Buffer = NULL;
+                status = STATUS_INSUFFICIENT_RESOURCES;
+                goto Exit;
             }
         }
 
-        if (process_notify_context->account_name.Buffer != NULL &&
-            process_notify_context->account_domain.Buffer != NULL) {
-            lookup_status = SecLookupAccountSid(
-                token_user->User.Sid,
-                &name_size,
-                &process_notify_context->account_name,
-                &domain_size,
-                &process_notify_context->account_domain,
-                &name_use);
-        }
-
-        if (!NT_SUCCESS(lookup_status)) {
-            if (name_heap_allocated) {
-                ExFreePool(process_notify_context->account_name.Buffer);
-            }
-            process_notify_context->account_name.Buffer = NULL;
-            process_notify_context->account_name.Length = 0;
-            process_notify_context->account_name.MaximumLength = 0;
-            if (domain_heap_allocated) {
-                ExFreePool(process_notify_context->account_domain.Buffer);
-            }
-            process_notify_context->account_domain.Buffer = NULL;
-            process_notify_context->account_domain.Length = 0;
-            process_notify_context->account_domain.MaximumLength = 0;
-        }
-    } else if (!NT_SUCCESS(lookup_status)) {
-        // Lookup failed for a reason other than buffer size — clear results.
-        process_notify_context->account_name.Length = 0;
-        process_notify_context->account_domain.Length = 0;
+        status = SecLookupAccountSid(
+            token_user->User.Sid,
+            &name_size,
+            &process_notify_context->account_name,
+            &domain_size,
+            &process_notify_context->account_domain,
+            &name_use);
     }
 
-    ExFreePool(token_user);
-    PsDereferencePrimaryToken(token);
+    if (!NT_SUCCESS(status)) {
+        goto Exit;
+    }
+
+    process_notify_context->account_lookup_done = TRUE;
+
+Exit:
+    if (!NT_SUCCESS(status)) {
+        // Clear account results on failure.
+        if (name_heap_allocated) {
+            ExFreePool(process_notify_context->account_name.Buffer);
+        }
+        process_notify_context->account_name.Buffer = NULL;
+        process_notify_context->account_name.Length = 0;
+        process_notify_context->account_name.MaximumLength = 0;
+        if (domain_heap_allocated) {
+            ExFreePool(process_notify_context->account_domain.Buffer);
+        }
+        process_notify_context->account_domain.Buffer = NULL;
+        process_notify_context->account_domain.Length = 0;
+        process_notify_context->account_domain.MaximumLength = 0;
+    }
+
+    if (token_user != NULL) {
+        ExFreePool(token_user);
+    }
+    if (token != NULL) {
+        PsDereferencePrimaryToken(token);
+    }
+
+    return status;
 }
 
 _Success_(return >= 0) static int32_t _ebpf_process_get_account_name(
     _In_ process_md_t* process_md, _Out_writes_bytes_(name_length) uint8_t* name, uint32_t name_length)
 {
+    int32_t result = 0;
     process_notify_context_t* process_notify_context =
         CONTAINING_RECORD(process_md, process_notify_context_t, process_md);
-    _ebpf_process_resolve_account(process_notify_context);
-    int32_t result = 0;
+    NTSTATUS status = _ebpf_process_resolve_account(process_notify_context);
+    if (!NT_SUCCESS(status)) {
+        EBPF_EXT_LOG_MESSAGE_NTSTATUS(
+            EBPF_EXT_TRACELOG_LEVEL_WARNING,
+            EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
+            "Failed to resolve account name",
+            status);
+        result = -ENOENT;
+        goto Exit;
+    }
     if (process_notify_context->account_name.Length > name_length) {
-        return -EINVAL;
+        result = -EINVAL;
+        goto Exit;
     }
     if (process_notify_context->account_name.Buffer != NULL) {
         if (name_length >= process_notify_context->account_name.Length) {
@@ -793,18 +825,30 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_account_name(
             result = process_notify_context->account_name.Length;
         }
     }
+
+Exit:
     return result;
 }
 
 _Success_(return >= 0) static int32_t _ebpf_process_get_account_domain(
     _In_ process_md_t* process_md, _Out_writes_bytes_(domain_length) uint8_t* domain, uint32_t domain_length)
 {
+    int32_t result = 0;
     process_notify_context_t* process_notify_context =
         CONTAINING_RECORD(process_md, process_notify_context_t, process_md);
-    _ebpf_process_resolve_account(process_notify_context);
-    int32_t result = 0;
+    NTSTATUS status = _ebpf_process_resolve_account(process_notify_context);
+    if (!NT_SUCCESS(status)) {
+        EBPF_EXT_LOG_MESSAGE_NTSTATUS(
+            EBPF_EXT_TRACELOG_LEVEL_WARNING,
+            EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
+            "Failed to resolve account domain",
+            status);
+        result = -ENOENT;
+        goto Exit;
+    }
     if (process_notify_context->account_domain.Length > domain_length) {
-        return -EINVAL;
+        result = -EINVAL;
+        goto Exit;
     }
     if (process_notify_context->account_domain.Buffer != NULL) {
         if (domain_length >= process_notify_context->account_domain.Length) {
@@ -813,5 +857,7 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_account_domain(
             result = process_notify_context->account_domain.Length;
         }
     }
+
+Exit:
     return result;
 }

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -254,6 +254,16 @@ typedef struct _process_notify_context
     BOOLEAN account_lookup_done;
 } process_notify_context_t;
 
+// Wrapper used only by context_create/context_destroy (bpf_prog_test_run path).
+// Tracks the initial account buffers so context_destroy can free them if
+// _ebpf_process_resolve_account replaced them with heap-allocated buffers.
+typedef struct _process_test_context
+{
+    process_notify_context_t base;
+    PWSTR account_name_initial_buffer;
+    PWSTR account_domain_initial_buffer;
+} process_test_context_t;
+
 // Deep-copy a UNICODE_STRING from a packed data buffer, advancing the data pointer.
 static ebpf_result_t
 _deep_copy_unicode_string_from_data(
@@ -303,6 +313,7 @@ _ebpf_process_context_create(
 {
     EBPF_EXT_LOG_ENTRY();
     ebpf_result_t result;
+    process_test_context_t* test_context = NULL;
     process_notify_context_t* process_context = NULL;
     process_notify_context_t* input_context = NULL;
     const uint8_t* data_ptr = data_in;
@@ -340,10 +351,12 @@ _ebpf_process_context_create(
         goto Exit;
     }
 
-    process_context = (process_notify_context_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(process_notify_context_t), EBPF_EXTENSION_POOL_TAG);
-    EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
-        EBPF_EXT_TRACELOG_KEYWORD_PROCESS, process_context, "process_context", result);
+    test_context = (process_test_context_t*)ExAllocatePoolUninitialized(
+        NonPagedPoolNx, sizeof(process_test_context_t), EBPF_EXTENSION_POOL_TAG);
+    EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(EBPF_EXT_TRACELOG_KEYWORD_PROCESS, test_context, "process_context", result);
+
+    memset(test_context, 0, sizeof(process_test_context_t));
+    process_context = &test_context->base;
 
     // Copy the context from the caller.
     memcpy(process_context, context_in, sizeof(process_notify_context_t));
@@ -352,8 +365,6 @@ _ebpf_process_context_create(
     // These are kernel pointers that must be NULL when creating context from user mode.
     process_context->process = NULL;
     process_context->create_info = NULL;
-    // Test contexts have account data provided in data_in, so skip lazy lookup.
-    process_context->account_lookup_done = TRUE;
 
     // Parse data_in buffer: [command_line][image_file_name][account_name][account_domain]
     // The lengths are specified in the UNICODE_STRING structures from the context.
@@ -394,17 +405,23 @@ _ebpf_process_context_create(
         goto Exit;
     }
 
+    // Save initial buffer pointers so context_destroy can free them if
+    // _ebpf_process_resolve_account replaced them with heap-allocated buffers.
+    test_context->account_name_initial_buffer = process_context->account_name.Buffer;
+    test_context->account_domain_initial_buffer = process_context->account_domain.Buffer;
+
     // Set command_start and command_end to point to the copied command_line buffer
     process_context->process_md.command_start = (uint8_t*)process_context->command_line.Buffer;
     process_context->process_md.command_end =
         (uint8_t*)process_context->command_line.Buffer + process_context->command_line.Length;
 
     *context = &process_context->process_md;
-    process_context = NULL;
+    test_context = NULL;
     result = EBPF_SUCCESS;
 
 Exit:
-    if (process_context) {
+    if (test_context) {
+        process_context = &test_context->base;
         if (process_context->command_line.Buffer != NULL) {
             ExFreePool(process_context->command_line.Buffer);
         }
@@ -417,8 +434,8 @@ Exit:
         if (process_context->account_domain.Buffer != NULL) {
             ExFreePool(process_context->account_domain.Buffer);
         }
-        ExFreePool(process_context);
-        process_context = NULL;
+        ExFreePool(test_context);
+        test_context = NULL;
     }
     EBPF_EXT_RETURN_RESULT(result);
 }
@@ -496,12 +513,25 @@ _ebpf_process_context_destroy(
         *data_size_out = 0;
     }
 
-    // Free the deep-copied buffers
+    // Free the deep-copied buffers.
+    // Recover the test wrapper to check if _ebpf_process_resolve_account replaced
+    // account buffers with heap-allocated ones.
     if (process_context->command_line.Buffer != NULL) {
         ExFreePool(process_context->command_line.Buffer);
     }
     if (process_context->image_file_name.Buffer != NULL) {
         ExFreePool(process_context->image_file_name.Buffer);
+    }
+    {
+        process_test_context_t* test_context = CONTAINING_RECORD(process_context, process_test_context_t, base);
+        if (test_context->account_name_initial_buffer != NULL &&
+            test_context->account_name_initial_buffer != process_context->account_name.Buffer) {
+            ExFreePool(test_context->account_name_initial_buffer);
+        }
+        if (test_context->account_domain_initial_buffer != NULL &&
+            test_context->account_domain_initial_buffer != process_context->account_domain.Buffer) {
+            ExFreePool(test_context->account_domain_initial_buffer);
+        }
     }
     if (process_context->account_name.Buffer != NULL) {
         ExFreePool(process_context->account_name.Buffer);
@@ -509,7 +539,7 @@ _ebpf_process_context_destroy(
     if (process_context->account_domain.Buffer != NULL) {
         ExFreePool(process_context->account_domain.Buffer);
     }
-    ExFreePool(process_context);
+    ExFreePool(CONTAINING_RECORD(process_context, process_test_context_t, base));
 
 Exit:
     EBPF_EXT_LOG_EXIT();
@@ -642,43 +672,32 @@ _Success_(return >= 0) static int32_t _ebpf_process_get_image_path(
 
 // Lazily resolve the account name and domain from the process token SID.
 // Called on first invocation of either account helper; results are cached.
-// The process creation notify routine runs at PASSIVE_LEVEL, so PsReferencePrimaryToken is safe to call.
 static NTSTATUS
 _ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
-    PTOKEN_USER token_user = NULL;
-    PACCESS_TOKEN token = NULL;
     BOOLEAN name_heap_allocated = FALSE;
     BOOLEAN domain_heap_allocated = FALSE;
     ULONG name_size = 0;
     ULONG domain_size = 0;
     SID_NAME_USE name_use;
-
-    ebpf_assert(KeGetCurrentIrql() == PASSIVE_LEVEL);
+    PSID sid = (PSID)process_notify_context->process_md.token_sid;
 
     if (process_notify_context->account_lookup_done) {
-        return STATUS_SUCCESS;
+        // On a previous failure the cleanup code set Buffer to NULL.
+        return (process_notify_context->account_name.Buffer != NULL &&
+                process_notify_context->account_domain.Buffer != NULL)
+                   ? STATUS_SUCCESS
+                   : STATUS_UNSUCCESSFUL;
     }
 
-    if (process_notify_context->process == NULL) {
-        status = STATUS_INVALID_PARAMETER;
-        goto Exit;
-    }
-
-    token = PsReferencePrimaryToken(process_notify_context->process);
-    ebpf_assert(token != NULL);
-    if (token == NULL) {
+    // The SID was already captured by the notify routine into process_md.token_sid.
+    if (process_notify_context->process_md.token_sid_size == 0) {
         status = STATUS_UNSUCCESSFUL;
         goto Exit;
     }
 
-    status = SeQueryInformationToken(token, TokenUser, (PVOID*)&token_user);
-    if (!NT_SUCCESS(status) || token_user == NULL) {
-        goto Exit;
-    }
-
-    if (!RtlValidSid(token_user->User.Sid)) {
+    if (!RtlValidSid(sid)) {
         status = STATUS_UNSUCCESSFUL;
         goto Exit;
     }
@@ -688,7 +707,7 @@ _ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_c
 
     // Try the lookup optimistically with the existing (stack) buffers.
     status = SecLookupAccountSid(
-        token_user->User.Sid,
+        sid,
         &name_size,
         &process_notify_context->account_name,
         &domain_size,
@@ -728,7 +747,7 @@ _ebpf_process_resolve_account(_Inout_ process_notify_context_t* process_notify_c
         }
 
         status = SecLookupAccountSid(
-            token_user->User.Sid,
+            sid,
             &name_size,
             &process_notify_context->account_name,
             &domain_size,
@@ -758,13 +777,6 @@ Exit:
         process_notify_context->account_domain.Buffer = NULL;
         process_notify_context->account_domain.Length = 0;
         process_notify_context->account_domain.MaximumLength = 0;
-    }
-
-    if (token_user != NULL) {
-        ExFreePool(token_user);
-    }
-    if (token != NULL) {
-        PsDereferencePrimaryToken(token);
     }
 
     return status;

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_process.c
@@ -453,6 +453,26 @@ _ebpf_process_create_process_notify_routine_ex(
         process_notify_context.process_md.command_start = (uint8_t*)process_notify_context.command_line.Buffer;
         process_notify_context.process_md.command_end =
             (uint8_t*)process_notify_context.command_line.Buffer + process_notify_context.command_line.Length;
+
+        // Get the primary token SID for the new process.
+        {
+            PACCESS_TOKEN token = PsReferencePrimaryToken(process);
+            if (token != NULL) {
+                PTOKEN_USER token_user = NULL;
+                NTSTATUS sid_status = SeQueryInformationToken(token, TokenUser, (PVOID*)&token_user);
+                if (NT_SUCCESS(sid_status) && token_user != NULL) {
+                    if (RtlValidSid(token_user->User.Sid)) {
+                        ULONG sid_length = RtlLengthSid(token_user->User.Sid);
+                        if (sid_length <= TOKEN_SID_MAX_SIZE) {
+                            process_notify_context.process_md.token_sid_size = sid_length;
+                            memcpy(process_notify_context.process_md.token_sid, token_user->User.Sid, sid_length);
+                        }
+                    }
+                    ExFreePool(token_user);
+                }
+                PsDereferencePrimaryToken(token);
+            }
+        }
     } else {
         process_notify_context.process_md.operation = PROCESS_OPERATION_DELETE;
         process_notify_context.process_md.exit_time = PsGetProcessExitTime().QuadPart;

--- a/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_program_info.h
+++ b/ebpf_extensions/ntosebpfext/ntos_ebpf_ext_program_info.h
@@ -17,6 +17,18 @@ static const ebpf_helper_function_prototype_t _process_ebpf_extension_helper_fun
      .return_type = EBPF_RETURN_TYPE_INTEGER,
      .arguments =
          {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}},
+    {.header = {EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION, EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION_SIZE},
+     .helper_id = EBPF_MAX_GENERAL_HELPER_FUNCTION + 2,
+     .name = "bpf_process_get_account_name",
+     .return_type = EBPF_RETURN_TYPE_INTEGER,
+     .arguments =
+         {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}},
+    {.header = {EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION, EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION_SIZE},
+     .helper_id = EBPF_MAX_GENERAL_HELPER_FUNCTION + 3,
+     .name = "bpf_process_get_account_domain",
+     .return_type = EBPF_RETURN_TYPE_INTEGER,
+     .arguments =
+         {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_WRITABLE_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}},
 };
 
 static const ebpf_context_descriptor_t _ebpf_process_context_descriptor = {

--- a/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
+++ b/ebpf_extensions/ntosebpfext/sys/ntosebpfext.vcxproj
@@ -95,7 +95,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO;NDEBUG</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Platform)\$(ConfigurationName)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -117,7 +117,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
     </Midl>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\netio.lib;$(DDK_LIB_PATH)\ksecdd.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Platform)\$(ConfigurationName)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>

--- a/include/ebpf_ntos_hooks.h
+++ b/include/ebpf_ntos_hooks.h
@@ -56,6 +56,8 @@ process_hook_t(process_md_t* context);
 typedef enum
 {
     BPF_FUNC_process_get_image_path = PROCESS_EXT_HELPER_FN_BASE + 1,
+    BPF_FUNC_process_get_account_name = PROCESS_EXT_HELPER_FN_BASE + 2,
+    BPF_FUNC_process_get_account_domain = PROCESS_EXT_HELPER_FN_BASE + 3,
 } ebpf_process_helper_id_t;
 
 /**
@@ -71,4 +73,34 @@ typedef enum
 EBPF_HELPER(int, bpf_process_get_image_path, (process_md_t * ctx, uint8_t* path, uint32_t path_length));
 #ifndef __doxygen
 #define bpf_process_get_image_path ((bpf_process_get_image_path_t)BPF_FUNC_process_get_image_path)
+#endif
+
+/**
+ * @brief Get the account name associated with the process's primary token.
+ *
+ * @param[in] context Process metadata.
+ * @param[out] name Buffer to store the account name.
+ * @param[in] name_length Length of the buffer in bytes.
+ *
+ * @retval >=0 The length of the account name in bytes.
+ * @retval <0 A failure occurred.
+ */
+EBPF_HELPER(int, bpf_process_get_account_name, (process_md_t * ctx, uint8_t* name, uint32_t name_length));
+#ifndef __doxygen
+#define bpf_process_get_account_name ((bpf_process_get_account_name_t)BPF_FUNC_process_get_account_name)
+#endif
+
+/**
+ * @brief Get the account domain associated with the process's primary token.
+ *
+ * @param[in] context Process metadata.
+ * @param[out] domain Buffer to store the account domain.
+ * @param[in] domain_length Length of the buffer in bytes.
+ *
+ * @retval >=0 The length of the account domain in bytes.
+ * @retval <0 A failure occurred.
+ */
+EBPF_HELPER(int, bpf_process_get_account_domain, (process_md_t * ctx, uint8_t* domain, uint32_t domain_length));
+#ifndef __doxygen
+#define bpf_process_get_account_domain ((bpf_process_get_account_domain_t)BPF_FUNC_process_get_account_domain)
 #endif

--- a/include/ebpf_ntos_hooks.h
+++ b/include/ebpf_ntos_hooks.h
@@ -6,6 +6,8 @@
 // This file contains APIs for hooks and helpers that are
 // exposed by ntosebpfext.sys for use by eBPF programs.
 
+#define TOKEN_SID_MAX_SIZE 68 ///< Maximum size of a SID (SECURITY_MAX_SID_SIZE).
+
 typedef enum _process_operation
 {
     PROCESS_OPERATION_CREATE, ///< Process creation.
@@ -24,6 +26,8 @@ typedef struct _process_md
     uint64_t exit_time;                ///< Process exit time (as a FILETIME).  Set only for PROCESS_OPERATION_DELETE.
     uint32_t process_exit_code;        ///< Process exit status.  Set only for PROCESS_OPERATION_DELETE.
     process_operation_t operation : 8; ///< Operation to do.
+    uint32_t token_sid_size;           ///< Size of the token SID in bytes. Set only for PROCESS_OPERATION_CREATE.
+    uint8_t token_sid[TOKEN_SID_MAX_SIZE]; ///< Primary token SID. Set only for PROCESS_OPERATION_CREATE.
 } process_md_t;
 
 /*

--- a/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
+++ b/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
@@ -99,6 +99,7 @@ typedef struct test_process_notify_context
     UNICODE_STRING image_file_name;
     UNICODE_STRING account_name;
     UNICODE_STRING account_domain;
+    BOOLEAN account_lookup_done;
 } test_process_notify_context_t;
 
 _Must_inspect_result_ ebpf_result_t

--- a/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
+++ b/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
@@ -577,4 +577,212 @@ TEST_CASE("process_bpf_prog_run_test", "[ntosebpfext]")
     bpf_opts.data_size_in = static_cast<uint32_t>(total_data_size - 1);
     REQUIRE(bpf_prog_test_run_opts(process_program_fd, &bpf_opts) != 0);
 }
+
+TEST_CASE("process_resolve_account", "[ntosebpfext]")
+{
+    // Exercise _ebpf_process_resolve_account via bpf_prog_test_run.
+    // context_create no longer forces account_lookup_done = TRUE, so the BPF program's call
+    // to bpf_process_get_account_name triggers the lazy resolution using token_sid.
+    driver_service ntosebpfext_driver;
+    REQUIRE(
+        ntosebpfext_driver.create(L"ntosebpfext", driver_service::get_driver_path("ntosebpfext.sys").c_str()) == true);
+    REQUIRE(ntosebpfext_driver.start() == true);
+    auto cleanup_driver = wil::scope_exit([&]() {
+        ntosebpfext_driver.stop();
+        ntosebpfext_driver.unload();
+    });
+
+    struct bpf_object* object = bpf_object__open("process_monitor.sys");
+    REQUIRE(object != nullptr);
+    auto cleanup_object = wil::scope_exit([&]() { bpf_object__close(object); });
+
+    REQUIRE(bpf_object__load(object) == 0);
+
+    bpf_program* process_monitor = bpf_object__find_program_by_name(object, "ProcessMonitor");
+    REQUIRE(process_monitor != nullptr);
+
+    bpf_link* process_monitor_link = nullptr;
+    REQUIRE(
+        ebpf_program_attach(process_monitor, &EBPF_ATTACH_TYPE_PROCESS, nullptr, 0, &process_monitor_link) ==
+        EBPF_SUCCESS);
+    REQUIRE(process_monitor_link != nullptr);
+    auto cleanup_link = wil::scope_exit([&]() {
+        bpf_link_detach(bpf_link__fd(process_monitor_link));
+        bpf_link__destroy(process_monitor_link);
+    });
+
+    fd_t process_program_fd = bpf_program__fd(process_monitor);
+    REQUIRE(process_program_fd != ebpf_fd_invalid);
+
+    bpf_map* process_ringbuf_map = bpf_object__find_map_by_name(object, "process_ringbuf");
+    REQUIRE(process_ringbuf_map != nullptr);
+    ebpf_ring_buffer_opts ring_opts = {.sz = sizeof(ebpf_ring_buffer_opts), .flags = EBPF_RINGBUF_FLAG_AUTO_CALLBACK};
+    ring_buffer* process_ring_buffer =
+        ebpf_ring_buffer__new(bpf_map__fd(process_ringbuf_map), process_ringbuf_event_callback, nullptr, &ring_opts);
+    REQUIRE(process_ring_buffer != nullptr);
+    auto cleanup_ring_buffer = wil::scope_exit([&]() { ring_buffer__free(process_ring_buffer); });
+
+    bpf_map* account_name_map = bpf_object__find_map_by_name(object, "account_name_map");
+    REQUIRE(account_name_map != nullptr);
+    int account_name_map_fd = bpf_map__fd(account_name_map);
+    REQUIRE(account_name_map_fd != ebpf_fd_invalid);
+
+    bpf_map* account_domain_map = bpf_object__find_map_by_name(object, "account_domain_map");
+    REQUIRE(account_domain_map != nullptr);
+    int account_domain_map_fd = bpf_map__fd(account_domain_map);
+    REQUIRE(account_domain_map_fd != ebpf_fd_invalid);
+
+    std::wstring command_line = L"notepad.exe test.txt";
+    std::wstring image_path = L"C:\\Windows\\System32\\notepad.exe";
+    uint8_t test_sid[] = {
+        0x01, // Revision
+        0x01, // SubAuthorityCount
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x05, // IdentifierAuthority (NT Authority)
+        0x12,
+        0x00,
+        0x00,
+        0x00 // SubAuthority[0] = 18 (SECURITY_LOCAL_SYSTEM_RID)
+    };
+
+    // --- Scenario 1: Heap-fallback path ---
+    // Provide a valid SID but tiny account buffers (MaximumLength = 2) so SecLookupAccountSid
+    // returns STATUS_BUFFER_TOO_SMALL on the first try, forcing heap allocation and retry.
+    {
+        bpf_test_run_opts bpf_opts = {0};
+        test_process_notify_context_t process_ctx_in = {0};
+        test_process_notify_context_t process_ctx_out = {0};
+
+        process_ctx_in.process_md.process_id = TEST_PROCESS_ID;
+        process_ctx_in.process_md.operation = PROCESS_OPERATION_CREATE;
+        process_ctx_in.process_md.token_sid_size = sizeof(test_sid);
+        memcpy(process_ctx_in.process_md.token_sid, test_sid, sizeof(test_sid));
+
+        process_ctx_in.command_line.Length = static_cast<USHORT>(command_line.length() * sizeof(wchar_t));
+        process_ctx_in.command_line.MaximumLength = process_ctx_in.command_line.Length;
+        process_ctx_in.image_file_name.Length = static_cast<USHORT>(image_path.length() * sizeof(wchar_t));
+        process_ctx_in.image_file_name.MaximumLength = process_ctx_in.image_file_name.Length;
+
+        wchar_t dummy = L'X';
+        process_ctx_in.account_name.Length = sizeof(dummy);
+        process_ctx_in.account_name.MaximumLength = sizeof(dummy);
+        process_ctx_in.account_domain.Length = sizeof(dummy);
+        process_ctx_in.account_domain.MaximumLength = sizeof(dummy);
+
+        size_t total_data_size = static_cast<size_t>(process_ctx_in.command_line.Length) +
+                                 static_cast<size_t>(process_ctx_in.image_file_name.Length) +
+                                 static_cast<size_t>(process_ctx_in.account_name.Length) +
+                                 static_cast<size_t>(process_ctx_in.account_domain.Length);
+        std::vector<uint8_t> packed_data(total_data_size);
+
+        size_t offset = 0;
+        memcpy(packed_data.data() + offset, command_line.c_str(), process_ctx_in.command_line.Length);
+        offset += process_ctx_in.command_line.Length;
+        memcpy(packed_data.data() + offset, image_path.c_str(), process_ctx_in.image_file_name.Length);
+        offset += process_ctx_in.image_file_name.Length;
+        memcpy(packed_data.data() + offset, &dummy, process_ctx_in.account_name.Length);
+        offset += process_ctx_in.account_name.Length;
+        memcpy(packed_data.data() + offset, &dummy, process_ctx_in.account_domain.Length);
+
+        uint32_t event_count_before = process_event_count;
+        std::vector<uint8_t> data_out_buffer(1024);
+
+        bpf_opts.repeat = 1;
+        bpf_opts.ctx_in = &process_ctx_in;
+        bpf_opts.ctx_size_in = sizeof(process_ctx_in);
+        bpf_opts.ctx_out = &process_ctx_out;
+        bpf_opts.ctx_size_out = sizeof(process_ctx_out);
+        bpf_opts.data_in = packed_data.data();
+        bpf_opts.data_size_in = static_cast<uint32_t>(total_data_size);
+        bpf_opts.data_out = data_out_buffer.data();
+        bpf_opts.data_size_out = static_cast<uint32_t>(data_out_buffer.size());
+
+        REQUIRE(bpf_prog_test_run_opts(process_program_fd, &bpf_opts) == 0);
+
+        for (int i = 0; i < 5; i++) {
+            if (process_event_count == event_count_before + 1) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+        REQUIRE(process_event_count == event_count_before + 1);
+
+        uint32_t lookup_key = TEST_PROCESS_ID;
+        std::vector<wchar_t> account_name_from_map(ACCOUNT_NAME_SIZE / sizeof(wchar_t), L'\0');
+        REQUIRE(bpf_map_lookup_elem(account_name_map_fd, &lookup_key, account_name_from_map.data()) == 0);
+        REQUIRE(account_name_from_map[0] != L'\0');
+
+        std::vector<wchar_t> account_domain_from_map(ACCOUNT_DOMAIN_SIZE / sizeof(wchar_t), L'\0');
+        REQUIRE(bpf_map_lookup_elem(account_domain_map_fd, &lookup_key, account_domain_from_map.data()) == 0);
+        REQUIRE(account_domain_from_map[0] != L'\0');
+
+        // Delete the map entries so scenario 2 starts clean.
+        bpf_map_delete_elem(account_name_map_fd, &lookup_key);
+        bpf_map_delete_elem(account_domain_map_fd, &lookup_key);
+    }
+
+    // --- Scenario 2: Zero SID ---
+    // token_sid_size == 0 causes _ebpf_process_resolve_account to return failure,
+    // so the helpers return -ENOENT and the BPF program skips account map writes.
+    {
+        bpf_test_run_opts bpf_opts = {0};
+        test_process_notify_context_t process_ctx_in = {0};
+        test_process_notify_context_t process_ctx_out = {0};
+
+        process_ctx_in.process_md.process_id = TEST_PROCESS_ID;
+        process_ctx_in.process_md.operation = PROCESS_OPERATION_CREATE;
+        process_ctx_in.process_md.token_sid_size = 0;
+
+        process_ctx_in.command_line.Length = static_cast<USHORT>(command_line.length() * sizeof(wchar_t));
+        process_ctx_in.command_line.MaximumLength = process_ctx_in.command_line.Length;
+        process_ctx_in.image_file_name.Length = static_cast<USHORT>(image_path.length() * sizeof(wchar_t));
+        process_ctx_in.image_file_name.MaximumLength = process_ctx_in.image_file_name.Length;
+
+        size_t total_data_size = static_cast<size_t>(process_ctx_in.command_line.Length) +
+                                 static_cast<size_t>(process_ctx_in.image_file_name.Length);
+        std::vector<uint8_t> packed_data(total_data_size);
+
+        size_t offset = 0;
+        memcpy(packed_data.data() + offset, command_line.c_str(), process_ctx_in.command_line.Length);
+        offset += process_ctx_in.command_line.Length;
+        memcpy(packed_data.data() + offset, image_path.c_str(), process_ctx_in.image_file_name.Length);
+
+        uint32_t event_count_before = process_event_count;
+        std::vector<uint8_t> data_out_buffer(total_data_size);
+
+        bpf_opts.repeat = 1;
+        bpf_opts.ctx_in = &process_ctx_in;
+        bpf_opts.ctx_size_in = sizeof(process_ctx_in);
+        bpf_opts.ctx_out = &process_ctx_out;
+        bpf_opts.ctx_size_out = sizeof(process_ctx_out);
+        bpf_opts.data_in = packed_data.data();
+        bpf_opts.data_size_in = static_cast<uint32_t>(total_data_size);
+        bpf_opts.data_out = data_out_buffer.data();
+        bpf_opts.data_size_out = static_cast<uint32_t>(total_data_size);
+
+        REQUIRE(bpf_prog_test_run_opts(process_program_fd, &bpf_opts) == 0);
+
+        for (int i = 0; i < 5; i++) {
+            if (process_event_count == event_count_before + 1) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+        REQUIRE(process_event_count == event_count_before + 1);
+
+        REQUIRE(process_ctx_out.process_md.token_sid_size == 0);
+
+        uint32_t lookup_key = TEST_PROCESS_ID;
+        std::vector<wchar_t> account_name_from_map(ACCOUNT_NAME_SIZE / sizeof(wchar_t));
+        REQUIRE(bpf_map_lookup_elem(account_name_map_fd, &lookup_key, account_name_from_map.data()) != 0);
+
+        std::vector<wchar_t> account_domain_from_map(ACCOUNT_DOMAIN_SIZE / sizeof(wchar_t));
+        REQUIRE(bpf_map_lookup_elem(account_domain_map_fd, &lookup_key, account_domain_from_map.data()) != 0);
+    }
+}
+
 #pragma endregion process

--- a/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
+++ b/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
@@ -25,6 +25,8 @@
 
 #define MAX_IMAGE_PATH_SIZE (1024)
 #define MAX_COMMAND_LINE_SIZE ((64 * 1024))
+#define ACCOUNT_NAME_SIZE (64)
+#define ACCOUNT_DOMAIN_SIZE (512)
 #define TEST_PROCESS_ID 1234
 
 struct _DEVICE_OBJECT* _ebpf_ext_driver_device_object;
@@ -95,6 +97,8 @@ typedef struct test_process_notify_context
     void* create_info;
     UNICODE_STRING command_line;
     UNICODE_STRING image_file_name;
+    UNICODE_STRING account_name;
+    UNICODE_STRING account_domain;
 } test_process_notify_context_t;
 
 _Must_inspect_result_ ebpf_result_t
@@ -374,6 +378,8 @@ TEST_CASE("process_bpf_prog_run_test", "[ntosebpfext]")
     // Prepare test process data
     std::wstring command_line = L"notepad.exe test.txt";
     std::wstring image_path = L"C:\\Windows\\System32\\notepad.exe";
+    std::wstring account_name = L"SYSTEM";
+    std::wstring account_domain = L"NT AUTHORITY";
 
     process_ctx_in.process_md.process_id = TEST_PROCESS_ID;
     process_ctx_in.process_md.parent_process_id = 4567;
@@ -412,20 +418,33 @@ TEST_CASE("process_bpf_prog_run_test", "[ntosebpfext]")
     process_ctx_in.image_file_name.MaximumLength = process_ctx_in.image_file_name.Length;
     process_ctx_in.image_file_name.Buffer = NULL;
 
+    process_ctx_in.account_name.Length = static_cast<USHORT>(account_name.length() * sizeof(wchar_t));
+    process_ctx_in.account_name.MaximumLength = process_ctx_in.account_name.Length;
+    process_ctx_in.account_name.Buffer = NULL;
+
+    process_ctx_in.account_domain.Length = static_cast<USHORT>(account_domain.length() * sizeof(wchar_t));
+    process_ctx_in.account_domain.MaximumLength = process_ctx_in.account_domain.Length;
+    process_ctx_in.account_domain.Buffer = NULL;
+
     // Manually set command_start and command_end pointers to NULL (will be set by context_create)
     process_ctx_in.process_md.command_start = NULL;
     process_ctx_in.process_md.command_end = NULL;
 
-    // Pack both command_line and image_file_name data into a single buffer for data_in
+    // Pack command_line, image_file_name, account_name, and account_domain data into a single buffer for data_in
     size_t total_data_size = static_cast<size_t>(process_ctx_in.command_line.Length) +
-                             static_cast<size_t>(process_ctx_in.image_file_name.Length);
+                             static_cast<size_t>(process_ctx_in.image_file_name.Length) +
+                             static_cast<size_t>(process_ctx_in.account_name.Length) +
+                             static_cast<size_t>(process_ctx_in.account_domain.Length);
     std::vector<uint8_t> packed_data(total_data_size);
 
-    memcpy(packed_data.data(), command_line.c_str(), process_ctx_in.command_line.Length);
-    memcpy(
-        packed_data.data() + process_ctx_in.command_line.Length,
-        image_path.c_str(),
-        process_ctx_in.image_file_name.Length);
+    size_t offset = 0;
+    memcpy(packed_data.data() + offset, command_line.c_str(), process_ctx_in.command_line.Length);
+    offset += process_ctx_in.command_line.Length;
+    memcpy(packed_data.data() + offset, image_path.c_str(), process_ctx_in.image_file_name.Length);
+    offset += process_ctx_in.image_file_name.Length;
+    memcpy(packed_data.data() + offset, account_name.c_str(), process_ctx_in.account_name.Length);
+    offset += process_ctx_in.account_name.Length;
+    memcpy(packed_data.data() + offset, account_domain.c_str(), process_ctx_in.account_domain.Length);
 
     // Set up ring buffer consumer with auto-callback before running the test
     bpf_map* process_ringbuf_map = bpf_object__find_map_by_name(object, "process_ringbuf");
@@ -507,6 +526,29 @@ TEST_CASE("process_bpf_prog_run_test", "[ntosebpfext]")
     int result_command = bpf_map_lookup_elem(command_map_fd, &lookup_key, command_line_from_map.data());
     REQUIRE(result_command == 0);
     REQUIRE(wcscmp(command_line_from_map.data(), command_line.c_str()) == 0);
+
+    // Validate LRU_HASH maps: account_name_map and account_domain_map
+    bpf_map* account_name_map = bpf_object__find_map_by_name(object, "account_name_map");
+    REQUIRE(account_name_map != nullptr);
+    int account_name_map_fd = bpf_map__fd(account_name_map);
+    REQUIRE(account_name_map_fd != ebpf_fd_invalid);
+
+    bpf_map* account_domain_map = bpf_object__find_map_by_name(object, "account_domain_map");
+    REQUIRE(account_domain_map != nullptr);
+    int account_domain_map_fd = bpf_map__fd(account_domain_map);
+    REQUIRE(account_domain_map_fd != ebpf_fd_invalid);
+
+    // Lookup the process_id in account_name_map to verify account name was stored
+    std::vector<wchar_t> account_name_from_map(ACCOUNT_NAME_SIZE / sizeof(wchar_t));
+    int result_account_name = bpf_map_lookup_elem(account_name_map_fd, &lookup_key, account_name_from_map.data());
+    REQUIRE(result_account_name == 0);
+    REQUIRE(wcscmp(account_name_from_map.data(), account_name.c_str()) == 0);
+
+    // Lookup the process_id in account_domain_map to verify account domain was stored
+    std::vector<wchar_t> account_domain_from_map(ACCOUNT_DOMAIN_SIZE / sizeof(wchar_t));
+    int result_account_domain = bpf_map_lookup_elem(account_domain_map_fd, &lookup_key, account_domain_from_map.data());
+    REQUIRE(result_account_domain == 0);
+    REQUIRE(wcscmp(account_domain_from_map.data(), account_domain.c_str()) == 0);
 
     // Test negative cases
 

--- a/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
+++ b/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
@@ -577,5 +577,4 @@ TEST_CASE("process_bpf_prog_run_test", "[ntosebpfext]")
     bpf_opts.data_size_in = static_cast<uint32_t>(total_data_size - 1);
     REQUIRE(bpf_prog_test_run_opts(process_program_fd, &bpf_opts) != 0);
 }
-
 #pragma endregion process

--- a/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
+++ b/tests/ntosebpfext/ntosebpfext_unit/ntos_ebpfext_unit.cpp
@@ -47,6 +47,8 @@ typedef struct
     uint64_t exit_time;
     uint32_t process_exit_code;
     uint8_t operation;
+    uint32_t token_sid_size;
+    uint8_t token_sid[TOKEN_SID_MAX_SIZE];
 } process_info_t;
 
 static int
@@ -72,6 +74,7 @@ process_ringbuf_event_callback(void* ctx, void* data, size_t size)
         std::cout << "  Exit Time: " << info->exit_time << std::endl;
         std::cout << "  Exit Code: " << info->process_exit_code << std::endl;
         std::cout << "  Operation: " << (info->operation == 0 ? "CREATE" : "DELETE") << std::endl;
+        std::cout << "  Token SID Size: " << info->token_sid_size << std::endl;
         process_event_count++;
     }
 
@@ -154,6 +157,8 @@ TEST_CASE("process_invoke", "[ntosebpfext]")
     REQUIRE(client_context.process_context.process_exit_code == 0); // Should be 0 for creation events
     REQUIRE(create_info.CreationStatus == STATUS_ACCESS_DENIED);
     REQUIRE((int)client_context.process_context.operation == PROCESS_OPERATION_CREATE);
+    REQUIRE(client_context.process_context.token_sid_size > 0);
+    REQUIRE(client_context.process_context.token_sid_size <= TOKEN_SID_MAX_SIZE);
 
     // Test process termination.
     // Just verify that it doesn't crash.
@@ -164,6 +169,7 @@ TEST_CASE("process_invoke", "[ntosebpfext]")
     // process exit codes test below for that).
     REQUIRE(client_context.process_context.process_exit_code == -1);
     REQUIRE((int)client_context.process_context.operation == PROCESS_OPERATION_DELETE);
+    REQUIRE(client_context.process_context.token_sid_size == 0); // SID not set for delete events
 }
 
 TEST_CASE("process exit codes", "[ntosebpfext]")
@@ -378,6 +384,24 @@ TEST_CASE("process_bpf_prog_run_test", "[ntosebpfext]")
     process_ctx_in.process_md.creation_time = 123456789;
     process_ctx_in.process_md.exit_time = 0;
 
+    // Set up a test SID (well-known Local System SID: S-1-5-18).
+    uint8_t test_sid[] = {
+        0x01, // Revision
+        0x01, // SubAuthorityCount
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x05, // IdentifierAuthority (NT Authority)
+        0x12,
+        0x00,
+        0x00,
+        0x00 // SubAuthority[0] = 18 (SECURITY_LOCAL_SYSTEM_RID)
+    };
+    process_ctx_in.process_md.token_sid_size = sizeof(test_sid);
+    memcpy(process_ctx_in.process_md.token_sid, test_sid, sizeof(test_sid));
+
     // Set up UNICODE_STRING structures with only Length fields (Buffer will be NULL)
     // The actual data will be passed in data_in buffer
     process_ctx_in.command_line.Length = static_cast<USHORT>(command_line.length() * sizeof(wchar_t));
@@ -443,6 +467,12 @@ TEST_CASE("process_bpf_prog_run_test", "[ntosebpfext]")
     REQUIRE(process_ctx_out.process_md.process_id == process_ctx_in.process_md.process_id);
     REQUIRE(process_ctx_out.process_md.parent_process_id == process_ctx_in.process_md.parent_process_id);
     REQUIRE(process_ctx_out.process_md.operation == process_ctx_in.process_md.operation);
+    REQUIRE(process_ctx_out.process_md.token_sid_size == process_ctx_in.process_md.token_sid_size);
+    REQUIRE(
+        memcmp(
+            process_ctx_out.process_md.token_sid,
+            process_ctx_in.process_md.token_sid,
+            process_ctx_in.process_md.token_sid_size) == 0);
 
     // Validate that one event was written to the ring buffer
     // Wait for auto-callback to process events (up to 5 seconds)

--- a/tests/process_monitor.Tests/ProcessMonitorTests.cs
+++ b/tests/process_monitor.Tests/ProcessMonitorTests.cs
@@ -52,6 +52,7 @@ public class ProcessMonitorTests
         Assert.AreEqual((uint)Environment.ProcessId, createdArgs.ParentProcessId);
         Assert.AreEqual((uint)Environment.ProcessId, createdArgs.CreatingProcessId);
         Assert.AreEqual(expectedCreatingThreadId, createdArgs.CreatingThreadId);
+        Assert.IsFalse(string.IsNullOrEmpty(createdArgs.TokenSid), "TokenSid should be non-empty for process creation events");
 
         Assert.AreEqual(createdArgs.ImageFileName, destroyedArgs.ImageFileName);
         Assert.AreEqual(createdArgs.CommandLine, destroyedArgs.CommandLine);
@@ -69,6 +70,7 @@ public class ProcessMonitorTests
         Assert.AreEqual((uint)Environment.ProcessId, createdArgs.ParentProcessId);
         Assert.AreEqual((uint)Environment.ProcessId, createdArgs.CreatingProcessId);
         Assert.AreEqual(expectedCreatingThreadId, createdArgs.CreatingThreadId);
+        Assert.IsFalse(string.IsNullOrEmpty(createdArgs.TokenSid), "TokenSid should be non-empty for process creation events");
 
         Assert.AreEqual(createdArgs.ImageFileName, destroyedArgs.ImageFileName);
         Assert.AreEqual(createdArgs.CommandLine, destroyedArgs.CommandLine);
@@ -91,6 +93,7 @@ public class ProcessMonitorTests
         Assert.AreEqual((uint)Environment.ProcessId, createdArgs.CreatingProcessId);
         Assert.AreEqual(expectedCreatingThreadId, createdArgs.CreatingThreadId);
         Assert.AreEqual($"\"cmd.exe\" /c echo {longArgs}", createdArgs.CommandLine);
+        Assert.IsFalse(string.IsNullOrEmpty(createdArgs.TokenSid), "TokenSid should be non-empty for process creation events");
 
         Assert.AreEqual(createdArgs.ImageFileName, destroyedArgs.ImageFileName);
         Assert.AreEqual(createdArgs.CommandLine, destroyedArgs.CommandLine);

--- a/tests/process_monitor.Tests/ProcessMonitorTests.cs
+++ b/tests/process_monitor.Tests/ProcessMonitorTests.cs
@@ -53,6 +53,8 @@ public class ProcessMonitorTests
         Assert.AreEqual((uint)Environment.ProcessId, createdArgs.CreatingProcessId);
         Assert.AreEqual(expectedCreatingThreadId, createdArgs.CreatingThreadId);
         Assert.IsFalse(string.IsNullOrEmpty(createdArgs.TokenSid), "TokenSid should be non-empty for process creation events");
+        Assert.IsFalse(string.IsNullOrEmpty(createdArgs.AccountName), "AccountName should be non-empty for process creation events");
+        Assert.IsFalse(string.IsNullOrEmpty(createdArgs.AccountDomain), "AccountDomain should be non-empty for process creation events");
 
         Assert.AreEqual(createdArgs.ImageFileName, destroyedArgs.ImageFileName);
         Assert.AreEqual(createdArgs.CommandLine, destroyedArgs.CommandLine);
@@ -71,6 +73,8 @@ public class ProcessMonitorTests
         Assert.AreEqual((uint)Environment.ProcessId, createdArgs.CreatingProcessId);
         Assert.AreEqual(expectedCreatingThreadId, createdArgs.CreatingThreadId);
         Assert.IsFalse(string.IsNullOrEmpty(createdArgs.TokenSid), "TokenSid should be non-empty for process creation events");
+        Assert.IsFalse(string.IsNullOrEmpty(createdArgs.AccountName), "AccountName should be non-empty for process creation events");
+        Assert.IsFalse(string.IsNullOrEmpty(createdArgs.AccountDomain), "AccountDomain should be non-empty for process creation events");
 
         Assert.AreEqual(createdArgs.ImageFileName, destroyedArgs.ImageFileName);
         Assert.AreEqual(createdArgs.CommandLine, destroyedArgs.CommandLine);

--- a/tools/process_monitor.Library/ProcessCreatedEventArgs.cs
+++ b/tools/process_monitor.Library/ProcessCreatedEventArgs.cs
@@ -10,4 +10,5 @@ public readonly record struct ProcessCreatedEventArgs(
     uint ParentProcessId,
     uint CreatingProcessId,
     uint CreatingThreadId,
-    DateTime CreateTime);
+    DateTime CreateTime,
+    string TokenSid);

--- a/tools/process_monitor.Library/ProcessCreatedEventArgs.cs
+++ b/tools/process_monitor.Library/ProcessCreatedEventArgs.cs
@@ -11,4 +11,6 @@ public readonly record struct ProcessCreatedEventArgs(
     uint CreatingProcessId,
     uint CreatingThreadId,
     DateTime CreateTime,
-    string TokenSid);
+    string TokenSid,
+    string AccountName,
+    string AccountDomain);

--- a/tools/process_monitor.Library/ProcessMonitor.cs
+++ b/tools/process_monitor.Library/ProcessMonitor.cs
@@ -21,8 +21,8 @@ namespace process_monitor.Library
 
         internal void RaiseProcessCreated(in ProcessCreatedEventArgs e)
         {
-            _logger.LogDebug("Process created: PID:{pid}, Image:{imageFileName}, CommandLine:{commandLine}, ParentPID:{parentPid}, Create Time:{createTime}, TokenSID:{tokenSid}",
-                e.ProcessId, e.ImageFileName, e.CommandLine, e.ParentProcessId, e.CreateTime, e.TokenSid);
+            _logger.LogDebug("Process created: PID:{pid}, Image:{imageFileName}, CommandLine:{commandLine}, ParentPID:{parentPid}, Create Time:{createTime}, TokenSID:{tokenSid}, Account:{accountDomain}\\{accountName}",
+                e.ProcessId, e.ImageFileName, e.CommandLine, e.ParentProcessId, e.CreateTime, e.TokenSid, e.AccountDomain, e.AccountName);
 
             try
             {

--- a/tools/process_monitor.Library/ProcessMonitor.cs
+++ b/tools/process_monitor.Library/ProcessMonitor.cs
@@ -21,8 +21,8 @@ namespace process_monitor.Library
 
         internal void RaiseProcessCreated(in ProcessCreatedEventArgs e)
         {
-            _logger.LogDebug("Process created: PID:{pid}, Image:{imageFileName}, CommandLine:{commandLine}, ParentPID:{parentPid}, Create Time:{createTime}",
-                e.ProcessId, e.ImageFileName, e.CommandLine, e.ParentProcessId, e.CreateTime);
+            _logger.LogDebug("Process created: PID:{pid}, Image:{imageFileName}, CommandLine:{commandLine}, ParentPID:{parentPid}, Create Time:{createTime}, TokenSID:{tokenSid}",
+                e.ProcessId, e.ImageFileName, e.CommandLine, e.ParentProcessId, e.CreateTime, e.TokenSid);
 
             try
             {

--- a/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
+++ b/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
@@ -211,11 +211,13 @@ namespace process_monitor.Library
                     try
                     {
                         var sidBytes = new byte[evt->token_sid_size];
-                        Marshal.Copy((IntPtr)evt->token_sid, sidBytes, 0, (int)evt->token_sid_size);
+                        byte* tokenSidPtr = &evt->token_sid[0];
+                        Marshal.Copy((IntPtr)tokenSidPtr, sidBytes, 0, (int)evt->token_sid_size);
                         var sid = new SecurityIdentifier(sidBytes, 0);
                         tokenSidStr = sid.Value;
                     }
-                    catch { /* SID conversion failure is non-fatal */ }
+                    catch (ArgumentException) { /* SID conversion failure is non-fatal */ }
+                    catch (SystemException) { /* SID marshalling failure is non-fatal */ }
                 }
 
                 var createdArgs = new ProcessCreatedEventArgs()

--- a/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
+++ b/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
@@ -177,14 +177,19 @@ namespace process_monitor.Library
         private static unsafe string GetUnicodeStringFromBpfMapFD(int mapFD, process_info_t* evt)
         {
             Span<byte> utf16BytesOnStack = stackalloc byte[64 * 1024];
+            utf16BytesOnStack.Clear();
 
             var addrOfPID = (byte*)evt + process_info_t_process_id_offset;
             var byteSpanOfPID = new Span<byte>(addrOfPID, sizeof(uint));
 
-            PInvokes.bpf_map_lookup_elem(mapFD,
+            var result = PInvokes.bpf_map_lookup_elem(mapFD,
                                          key: ref MemoryMarshal.AsRef<byte>(byteSpanOfPID),
                                          value: ref MemoryMarshal.AsRef<byte>(utf16BytesOnStack));
 
+            if (result != 0)
+            {
+                return string.Empty;
+            }
             return Encoding.Unicode.GetString(utf16BytesOnStack).Trim('\0');
         }
 

--- a/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
+++ b/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
@@ -18,6 +18,10 @@ namespace process_monitor.Library
         private static int process_map_fd = 0;
         private static IntPtr command_map = IntPtr.Zero;
         private static int command_map_fd = 0;
+        private static IntPtr account_name_map = IntPtr.Zero;
+        private static int account_name_map_fd = 0;
+        private static IntPtr account_domain_map = IntPtr.Zero;
+        private static int account_domain_map_fd = 0;
         private static bool _isShutdown;
         private static readonly object _lock = new();
         private static readonly List<ProcessMonitor> _processMonitors = [];
@@ -106,6 +110,8 @@ namespace process_monitor.Library
                 }
                 (process_map, process_map_fd) = LoadMapByName("process_map", logger);
                 (command_map, command_map_fd) = LoadMapByName("command_map", logger);
+                (account_name_map, account_name_map_fd) = LoadMapByName("account_name_map", logger);
+                (account_domain_map, account_domain_map_fd) = LoadMapByName("account_domain_map", logger);
 
                 var process_monitor = PInvokes.bpf_object__find_program_by_name(process_monitor_bpfObject, "ProcessMonitor");
                 if (process_monitor == IntPtr.Zero)
@@ -194,6 +200,8 @@ namespace process_monitor.Library
 
             var file_name_str = GetUnicodeStringFromBpfMapFD(process_map_fd, evt);
             var command_line_str = GetUnicodeStringFromBpfMapFD(command_map_fd, evt);
+            var account_name_str = GetUnicodeStringFromBpfMapFD(account_name_map_fd, evt);
+            var account_domain_str = GetUnicodeStringFromBpfMapFD(account_domain_map_fd, evt);
 
             if (evt->operation == 0 /* 0 == PROCESS_OPERATION_COMPLETE */)
             {
@@ -219,7 +227,9 @@ namespace process_monitor.Library
                     CreatingProcessId = evt->creating_process_id,
                     CreatingThreadId = evt->creating_thread_id,
                     CreateTime = DateTime.FromFileTime((long)evt->creation_time),
-                    TokenSid = tokenSidStr
+                    TokenSid = tokenSidStr,
+                    AccountName = account_name_str,
+                    AccountDomain = account_domain_str
                 };
 
                 lock (_lock)

--- a/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
+++ b/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
@@ -200,11 +200,11 @@ namespace process_monitor.Library
 
             var file_name_str = GetUnicodeStringFromBpfMapFD(process_map_fd, evt);
             var command_line_str = GetUnicodeStringFromBpfMapFD(command_map_fd, evt);
-            var account_name_str = GetUnicodeStringFromBpfMapFD(account_name_map_fd, evt);
-            var account_domain_str = GetUnicodeStringFromBpfMapFD(account_domain_map_fd, evt);
 
             if (evt->operation == 0 /* 0 == PROCESS_OPERATION_COMPLETE */)
             {
+                var account_name_str = GetUnicodeStringFromBpfMapFD(account_name_map_fd, evt);
+                var account_domain_str = GetUnicodeStringFromBpfMapFD(account_domain_map_fd, evt);
                 string tokenSidStr = string.Empty;
                 if (evt->token_sid_size > 0 && evt->token_sid_size <= process_info_t.TOKEN_SID_MAX_SIZE)
                 {

--- a/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
+++ b/tools/process_monitor.Library/ProcessMonitorBPFLoader.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
@@ -25,9 +26,11 @@ namespace process_monitor.Library
         // Note: this must be kept in sync with the C version in process_monitor.sys (process_monitor.c)
         [StructLayout(LayoutKind.Sequential)]
 #pragma warning disable IDE1006 // Naming Styles - this matches the native definition's name
-        internal readonly struct process_info_t
+        internal struct process_info_t
 #pragma warning restore IDE1006 // Naming Styles
         {
+            internal const int TOKEN_SID_MAX_SIZE = 68;
+
             internal readonly UInt32 process_id;
             internal readonly UInt32 parent_process_id;
             internal readonly UInt32 creating_process_id;
@@ -36,6 +39,8 @@ namespace process_monitor.Library
             internal readonly UInt64 exit_time;
             internal readonly UInt32 process_exit_code;
             internal readonly byte operation;
+            internal readonly UInt32 token_sid_size;
+            internal unsafe fixed byte token_sid[TOKEN_SID_MAX_SIZE];
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -192,6 +197,19 @@ namespace process_monitor.Library
 
             if (evt->operation == 0 /* 0 == PROCESS_OPERATION_COMPLETE */)
             {
+                string tokenSidStr = string.Empty;
+                if (evt->token_sid_size > 0 && evt->token_sid_size <= process_info_t.TOKEN_SID_MAX_SIZE)
+                {
+                    try
+                    {
+                        var sidBytes = new byte[evt->token_sid_size];
+                        Marshal.Copy((IntPtr)evt->token_sid, sidBytes, 0, (int)evt->token_sid_size);
+                        var sid = new SecurityIdentifier(sidBytes, 0);
+                        tokenSidStr = sid.Value;
+                    }
+                    catch { /* SID conversion failure is non-fatal */ }
+                }
+
                 var createdArgs = new ProcessCreatedEventArgs()
                 {
                     ProcessId = evt->process_id,
@@ -200,7 +218,8 @@ namespace process_monitor.Library
                     ParentProcessId = evt->parent_process_id,
                     CreatingProcessId = evt->creating_process_id,
                     CreatingThreadId = evt->creating_thread_id,
-                    CreateTime = DateTime.FromFileTime((long)evt->creation_time)
+                    CreateTime = DateTime.FromFileTime((long)evt->creation_time),
+                    TokenSid = tokenSidStr
                 };
 
                 lock (_lock)

--- a/tools/process_monitor_bpf/process_monitor.c
+++ b/tools/process_monitor_bpf/process_monitor.c
@@ -149,11 +149,14 @@ ProcessMonitor(process_md_t* ctx)
     process_info.exit_time = ctx->exit_time;
     process_info.process_exit_code = ctx->process_exit_code;
     process_info.operation = ctx->operation;
-    process_info.token_sid_size = ctx->token_sid_size;
     if (ctx->token_sid_size > 0 && ctx->token_sid_size <= TOKEN_SID_MAX_SIZE) {
+        process_info.token_sid_size = ctx->token_sid_size;
         // Use __builtin_memcpy with a compile-time constant size to avoid the BPF verifier
         // rejecting ctx->token_sid (a context pointer) as source for the bpf_memcpy_s helper.
         __builtin_memcpy(process_info.token_sid, ctx->token_sid, TOKEN_SID_MAX_SIZE);
+    } else {
+        process_info.token_sid_size = 0;
+        memset(process_info.token_sid, 0, TOKEN_SID_MAX_SIZE);
     }
 
     if (process_info.operation == PROCESS_OPERATION_CREATE) {
@@ -181,14 +184,14 @@ ProcessMonitor(process_md_t* ctx)
         bpf_process_get_image_path(ctx, buffer, IMAGE_PATH_SIZE - 1);
         bpf_map_update_elem(&process_map, &process_info.process_id, buffer, BPF_ANY);
 
-        // Copy account name into the LRU hash.
+        // Copy account name into the LRU hash. Subtract 2 to leave room for a UTF-16 null terminator.
         memset(buffer, 0, MAX_ACCOUNT_NAME_SIZE);
-        bpf_process_get_account_name(ctx, buffer, MAX_ACCOUNT_NAME_SIZE - 1);
+        bpf_process_get_account_name(ctx, buffer, MAX_ACCOUNT_NAME_SIZE - 2);
         bpf_map_update_elem(&account_name_map, &process_info.process_id, buffer, BPF_ANY);
 
-        // Copy account domain into the LRU hash.
+        // Copy account domain into the LRU hash. Subtract 2 to leave room for a UTF-16 null terminator.
         memset(buffer, 0, MAX_ACCOUNT_DOMAIN_SIZE);
-        bpf_process_get_account_domain(ctx, buffer, MAX_ACCOUNT_DOMAIN_SIZE - 1);
+        bpf_process_get_account_domain(ctx, buffer, MAX_ACCOUNT_DOMAIN_SIZE - 2);
         bpf_map_update_elem(&account_domain_map, &process_info.process_id, buffer, BPF_ANY);
     }
     bpf_ringbuf_output(&process_ringbuf, &process_info, sizeof(process_info), 0);

--- a/tools/process_monitor_bpf/process_monitor.c
+++ b/tools/process_monitor_bpf/process_monitor.c
@@ -44,6 +44,8 @@ typedef struct
     uint64_t exit_time;     ///< Process exit time.
     uint32_t process_exit_code;
     uint8_t operation;
+    uint32_t token_sid_size;               ///< Size of the token SID in bytes.
+    uint8_t token_sid[TOKEN_SID_MAX_SIZE]; ///< Primary token SID.
 } process_info_t;
 
 // LRU hash for storing the image path of a process.
@@ -121,6 +123,12 @@ ProcessMonitor(process_md_t* ctx)
     process_info.exit_time = ctx->exit_time;
     process_info.process_exit_code = ctx->process_exit_code;
     process_info.operation = ctx->operation;
+    process_info.token_sid_size = ctx->token_sid_size;
+    if (ctx->token_sid_size > 0 && ctx->token_sid_size <= TOKEN_SID_MAX_SIZE) {
+        // Use __builtin_memcpy with a compile-time constant size to avoid the BPF verifier
+        // rejecting ctx->token_sid (a context pointer) as source for the bpf_memcpy_s helper.
+        __builtin_memcpy(process_info.token_sid, ctx->token_sid, TOKEN_SID_MAX_SIZE);
+    }
 
     if (process_info.operation == PROCESS_OPERATION_CREATE) {
         void* buffer = get_scratch_space();

--- a/tools/process_monitor_bpf/process_monitor.c
+++ b/tools/process_monitor_bpf/process_monitor.c
@@ -10,6 +10,14 @@
 
 #define IMAGE_PATH_SIZE (1024)
 
+// Account names are limited to 20 characters (20 * 2 = 40 bytes in UTF-16).
+// Rounding up to 64 bytes.
+#define MAX_ACCOUNT_NAME_SIZE (64)
+
+// NetBIOS domain names are limited to 15 characters, but DNS domain names can be
+// up to 255 characters (255 * 2 = 510 bytes in UTF-16). Using 512 to cover DNS domains.
+#define MAX_ACCOUNT_DOMAIN_SIZE (512)
+
 // 64k bytes is the max byte count that fits in a UNICODE_STRING (because Length is a USHORT).  Exactly 64k seems
 // to be a little too high for eBPF, so we subtract a few bytes and the likelihood this actually truncates anything
 // important is pretty low.
@@ -65,6 +73,24 @@ struct
     __type(value, char[COMMAND_SCRATCH_SIZE]);
     __uint(max_entries, 1024);
 } command_map SEC(".maps");
+
+// LRU hash for storing the account name of a process.
+struct
+{
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, uint32_t); // key is the process id.
+    __type(value, char[MAX_ACCOUNT_NAME_SIZE]);
+    __uint(max_entries, 1024);
+} account_name_map SEC(".maps");
+
+// LRU hash for storing the account domain of a process.
+struct
+{
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, uint32_t); // key is the process id.
+    __type(value, char[MAX_ACCOUNT_DOMAIN_SIZE]);
+    __uint(max_entries, 1024);
+} account_domain_map SEC(".maps");
 
 // Ring-buffer for process_info_t.
 struct
@@ -154,6 +180,16 @@ ProcessMonitor(process_md_t* ctx)
         // Copy image path into the LRU hash.  Note we use IMAGE_PATH_SIZE - 1 to leave a guaranteed null terminator
         bpf_process_get_image_path(ctx, buffer, IMAGE_PATH_SIZE - 1);
         bpf_map_update_elem(&process_map, &process_info.process_id, buffer, BPF_ANY);
+
+        // Copy account name into the LRU hash.
+        memset(buffer, 0, MAX_ACCOUNT_NAME_SIZE);
+        bpf_process_get_account_name(ctx, buffer, MAX_ACCOUNT_NAME_SIZE - 1);
+        bpf_map_update_elem(&account_name_map, &process_info.process_id, buffer, BPF_ANY);
+
+        // Copy account domain into the LRU hash.
+        memset(buffer, 0, MAX_ACCOUNT_DOMAIN_SIZE);
+        bpf_process_get_account_domain(ctx, buffer, MAX_ACCOUNT_DOMAIN_SIZE - 1);
+        bpf_map_update_elem(&account_domain_map, &process_info.process_id, buffer, BPF_ANY);
     }
     bpf_ringbuf_output(&process_ringbuf, &process_info, sizeof(process_info), 0);
     return 0;

--- a/tools/process_monitor_bpf/process_monitor.c
+++ b/tools/process_monitor_bpf/process_monitor.c
@@ -186,13 +186,17 @@ ProcessMonitor(process_md_t* ctx)
 
         // Copy account name into the LRU hash. Subtract 2 to leave room for a UTF-16 null terminator.
         memset(buffer, 0, MAX_ACCOUNT_NAME_SIZE);
-        bpf_process_get_account_name(ctx, buffer, MAX_ACCOUNT_NAME_SIZE - 2);
-        bpf_map_update_elem(&account_name_map, &process_info.process_id, buffer, BPF_ANY);
+        int name_result = bpf_process_get_account_name(ctx, buffer, MAX_ACCOUNT_NAME_SIZE - 2);
+        if (name_result >= 0) {
+            bpf_map_update_elem(&account_name_map, &process_info.process_id, buffer, BPF_ANY);
+        }
 
         // Copy account domain into the LRU hash. Subtract 2 to leave room for a UTF-16 null terminator.
         memset(buffer, 0, MAX_ACCOUNT_DOMAIN_SIZE);
-        bpf_process_get_account_domain(ctx, buffer, MAX_ACCOUNT_DOMAIN_SIZE - 2);
-        bpf_map_update_elem(&account_domain_map, &process_info.process_id, buffer, BPF_ANY);
+        int domain_result = bpf_process_get_account_domain(ctx, buffer, MAX_ACCOUNT_DOMAIN_SIZE - 2);
+        if (domain_result >= 0) {
+            bpf_map_update_elem(&account_domain_map, &process_info.process_id, buffer, BPF_ANY);
+        }
     }
     bpf_ringbuf_output(&process_ringbuf, &process_info, sizeof(process_info), 0);
     return 0;


### PR DESCRIPTION
This pull request adds support for retrieving the primary token SID, account name, and account domain for newly created processes in the `ntosebpfext` extension. It introduces new helper functions and extends the process metadata structure and context management to include these fields. Closes #321 
This pr is blocked on merging https://github.com/microsoft/usersim/pull/298 into usersim.

**Process token and account information support:**

* Extended the `process_md_t` structure to include `token_sid_size` and `token_sid` fields, capturing the primary token SID for new processes, and updated documentation to reflect these additions. [[1]](diffhunk://#diff-43f48d2ee61751f89c48c68e51242766ce2da13376c2f1140ca9559150caa584R105-R106) [[2]](diffhunk://#diff-43f48d2ee61751f89c48c68e51242766ce2da13376c2f1140ca9559150caa584R243-R246)
* In the process creation notify routine, implemented logic to extract the primary token SID and resolve it to the account name and domain, storing them in the process context.

**New helper functions for eBPF programs:**

* Added two new helper functions, `bpf_process_get_account_name` and `bpf_process_get_account_domain`, to retrieve the account name and domain from the process context, and updated the helper function table and documentation accordingly. [[1]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410L41-R51) [[2]](diffhunk://#diff-43f48d2ee61751f89c48c68e51242766ce2da13376c2f1140ca9559150caa584L148-R150) [[3]](diffhunk://#diff-43f48d2ee61751f89c48c68e51242766ce2da13376c2f1140ca9559150caa584R189-R222) [[4]](diffhunk://#diff-43f48d2ee61751f89c48c68e51242766ce2da13376c2f1140ca9559150caa584L247-R287) [[5]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410R687-R723)

**Process context and memory management:**

* Updated the process context creation and destruction logic to deep copy, manage, and free the new account name and domain buffers, ensuring correct handling of variable-length fields and memory safety. [[1]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410R247-R248) [[2]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410L263-R280) [[3]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410R347-R392) [[4]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410R410-R415) [[5]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410R451-R462) [[6]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410R478-R489) [[7]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410L422-R507) [[8]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410L434-R525) [[9]](diffhunk://#diff-f3dc197ddd4a8f122c6a3b15be2c93c9110d91024aa704b435a391e2fe561410R660-R665)

**Other:**

* Updated the `usersim` submodule URL to point to a different repository.## Description

_Describe the purpose of and changes within this Pull Request._

## Testing

Added tests for newly added helpers.

## Documentation

Changes in the context structure have been documented,

## Installation

NA