### PR TITLE
Add LLVM/clang toolchain and build output copy for OneBranch builds

### DIFF
--- a/scripts/onebranch/copy-build-output.ps1
+++ b/scripts/onebranch/copy-build-output.ps1
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# Copies MSBuild output from the standard Visual Studio output directory to the
+# OneBranch output directory so that build artifacts are published correctly.
+# This script is intended for test/CI builds that compile the full solution
+# (as opposed to the /t:tools\onebranch target used by official builds).
+#
+# Environment variables (set by OneBranch):
+#   ONEBRANCH_ARCH             - Build architecture (e.g., x64)
+#   ONEBRANCH_CONFIG           - Build configuration (e.g., Debug, Release)
+#   ONEBRANCH_OUTPUTDIRECTORY  - OneBranch artifact output directory
+
+$ErrorActionPreference = 'Stop'
+
+$arch   = $env:ONEBRANCH_ARCH
+$config = $env:ONEBRANCH_CONFIG
+$dst    = $env:ONEBRANCH_OUTPUTDIRECTORY
+
+if (-not $arch -or -not $config -or -not $dst) {
+    throw "Required environment variables (ONEBRANCH_ARCH, ONEBRANCH_CONFIG, ONEBRANCH_OUTPUTDIRECTORY) are not set."
+}
+
+$src = Join-Path $arch $config
+
+if (-not (Test-Path $src)) {
+    throw "Source directory '$src' does not exist. Build may have failed."
+}
+
+Write-Host "Copying build output from '$src' to '$dst'..."
+
+if (-not (Test-Path $dst)) {
+    New-Item -ItemType Directory -Path $dst -Force | Out-Null
+}
+
+# Use robocopy for reliable directory mirroring. Exit codes 0-7 are success.
+robocopy $src $dst /E /NP /NFL /NDL
+if ($LASTEXITCODE -gt 7) {
+    throw "robocopy failed with exit code $LASTEXITCODE"
+}
+# Robocopy returns 1 when files are copied successfully. Reset so ADO does not
+# treat the non-zero exit code as a failure.
+$global:LASTEXITCODE = 0
+
+Write-Host "Build output copy complete."
+exit 0

--- a/scripts/onebranch/copy-build-output.ps1
+++ b/scripts/onebranch/copy-build-output.ps1
@@ -33,7 +33,7 @@ if (-not (Test-Path $dst)) {
     New-Item -ItemType Directory -Path $dst -Force | Out-Null
 }
 
-# Use robocopy for reliable directory mirroring. Exit codes 0-7 are success.
+# Use robocopy for a reliable recursive copy. Exit codes 0-7 are success.
 robocopy $src $dst /E /NP /NFL /NDL
 if ($LASTEXITCODE -gt 7) {
     throw "robocopy failed with exit code $LASTEXITCODE"

--- a/scripts/onebranch/pre-build.ps1
+++ b/scripts/onebranch/pre-build.ps1
@@ -35,7 +35,7 @@ try {
     # llvm.tools NuGet package does not ship the builtin headers (stdbool.h, etc.).
     # The clang.headers NuGet package provides them at packages\clang.headers\include\.
     # Copy them to the resource directory so clang can find them automatically.
-    $clangResourceDir = (& "$llvmPath\clang.exe" --print-resource-dir 2>&1).Trim()
+    $clangResourceDir = (& "$llvmPath\clang.exe" --print-resource-dir).Trim()
     if ($LASTEXITCODE -ne 0 -or -not $clangResourceDir) { throw "Failed to query clang resource directory: $clangResourceDir" }
     $clangResourceInclude = Join-Path $clangResourceDir "include"
     if (-not (Test-Path $clangResourceInclude)) {

--- a/scripts/onebranch/pre-build.ps1
+++ b/scripts/onebranch/pre-build.ps1
@@ -15,6 +15,35 @@ try {
     Copy-Item .\scripts\onebranch\nuget.config .\nuget.config
     .\scripts\initialize_repo.ps1
 
+    # Install LLVM tools (clang with BPF target support) for compiling eBPF programs.
+    Write-Host "Installing LLVM tools..."
+    nuget install llvm.tools -OutputDirectory packages -version 19.1.4-34 -ExcludeVersion
+    if ($LASTEXITCODE -ne 0) { throw "Failed to install llvm.tools" }
+    nuget install clang.headers -OutputDirectory packages -version 19.1.4-34 -ExcludeVersion
+    if ($LASTEXITCODE -ne 0) { throw "Failed to install clang.headers" }
+
+    # Add LLVM tools to PATH so clang is available for BPF compilation.
+    $llvmPath = Join-Path (Get-Location) "packages\llvm.tools"
+    $env:Path = "$llvmPath;$env:Path"
+    Write-Host "##vso[task.prependpath]$llvmPath"
+    Write-Host "LLVM tools installed. Clang version:"
+    clang --version
+
+    # Place clang builtin headers where the clang resource directory expects them.
+    # clang --print-resource-dir resolves to <llvm.tools>\lib\clang\<major>, but the
+    # llvm.tools NuGet package does not ship the builtin headers (stdbool.h, etc.).
+    # The clang.headers NuGet package provides them at packages\clang.headers\include\.
+    # Copy them to the resource directory so clang can find them automatically.
+    $clangResourceDir = & "$llvmPath\clang.exe" --print-resource-dir 2>&1
+    $clangResourceInclude = Join-Path $clangResourceDir "include"
+    if (-not (Test-Path $clangResourceInclude)) {
+        New-Item -ItemType Directory -Path $clangResourceInclude -Force | Out-Null
+    }
+    $headersSource = Join-Path (Get-Location) "packages\clang.headers\include"
+    Write-Host "Copying clang headers from '$headersSource' to '$clangResourceInclude'..."
+    Copy-Item -Path "$headersSource\*" -Destination $clangResourceInclude -Recurse -Force
+    Write-Host "Clang builtin headers installed."
+
     # Copy any scripts that will be packaged into the output folder
     $OutputScriptsFolder = Join-Path $OutputBinFolder "scripts"
     if (-not (Test-Path -Path $OutputScriptsFolder)) {

--- a/scripts/onebranch/pre-build.ps1
+++ b/scripts/onebranch/pre-build.ps1
@@ -28,13 +28,15 @@ try {
     Write-Host "##vso[task.prependpath]$llvmPath"
     Write-Host "LLVM tools installed. Clang version:"
     clang --version
+    if ($LASTEXITCODE -ne 0) { throw "Failed to run clang --version" }
 
     # Place clang builtin headers where the clang resource directory expects them.
     # clang --print-resource-dir resolves to <llvm.tools>\lib\clang\<major>, but the
     # llvm.tools NuGet package does not ship the builtin headers (stdbool.h, etc.).
     # The clang.headers NuGet package provides them at packages\clang.headers\include\.
     # Copy them to the resource directory so clang can find them automatically.
-    $clangResourceDir = & "$llvmPath\clang.exe" --print-resource-dir 2>&1
+    $clangResourceDir = (& "$llvmPath\clang.exe" --print-resource-dir 2>&1).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $clangResourceDir) { throw "Failed to query clang resource directory: $clangResourceDir" }
     $clangResourceInclude = Join-Path $clangResourceDir "include"
     if (-not (Test-Path $clangResourceInclude)) {
         New-Item -ItemType Directory -Path $clangResourceInclude -Force | Out-Null

--- a/scripts/onebranch/pre-build.ps1
+++ b/scripts/onebranch/pre-build.ps1
@@ -17,18 +17,18 @@ try {
 
     # Install LLVM tools (clang with BPF target support) for compiling eBPF programs.
     Write-Host "Installing LLVM tools..."
-nuget install llvm.tools -OutputDirectory packages -version 19.1.4-34 -ExcludeVersion
-if ($LASTEXITCODE -ne 0) { Write-Error "Failed to install llvm.tools (exit code $LASTEXITCODE)"; exit $LASTEXITCODE }
-nuget install clang.headers -OutputDirectory packages -version 19.1.4-34 -ExcludeVersion
-if ($LASTEXITCODE -ne 0) { Write-Error "Failed to install clang.headers (exit code $LASTEXITCODE)"; exit $LASTEXITCODE }
+    nuget install llvm.tools -OutputDirectory packages -Version 19.1.4-34 -ExcludeVersion
+    if ($LASTEXITCODE -ne 0) { Write-Error "Failed to install llvm.tools (exit code $LASTEXITCODE)"; exit $LASTEXITCODE }
+    nuget install clang.headers -OutputDirectory packages -Version 19.1.4-34 -ExcludeVersion
+    if ($LASTEXITCODE -ne 0) { Write-Error "Failed to install clang.headers (exit code $LASTEXITCODE)"; exit $LASTEXITCODE }
 
     # Add LLVM tools to PATH so clang is available for BPF compilation.
     $llvmPath = Join-Path (Get-Location) "packages\llvm.tools"
     $env:Path = "$llvmPath;$env:Path"
     Write-Host "##vso[task.prependpath]$llvmPath"
-Write-Host "LLVM tools installed. Clang version:"
-& "$llvmPath\clang.exe" --version
-if ($LASTEXITCODE -ne 0) { Write-Error "Failed to run clang --version (exit code $LASTEXITCODE)"; exit $LASTEXITCODE }
+    Write-Host "LLVM tools installed. Clang version:"
+    & "$llvmPath\clang.exe" --version
+    if ($LASTEXITCODE -ne 0) { Write-Error "Failed to run clang --version (exit code $LASTEXITCODE)"; exit $LASTEXITCODE }
 
     # Place clang builtin headers where the clang resource directory expects them.
     # clang --print-resource-dir resolves to <llvm.tools>\lib\clang\<major>, but the
@@ -41,10 +41,10 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Failed to run clang --version (exit code
     if (-not (Test-Path $clangResourceInclude)) {
         New-Item -ItemType Directory -Path $clangResourceInclude -Force | Out-Null
     }
-$headersSource = Join-Path (Get-Location) "packages\clang.headers\include"
-if (-not (Test-Path -Path $headersSource -PathType Container)) { Write-Error "Clang headers directory not found: $headersSource"; exit 1 }
-Write-Host "Copying clang headers from '$headersSource' to '$clangResourceInclude'..."
-Copy-Item -Path "$headersSource\*" -Destination $clangResourceInclude -Recurse -Force
+    $headersSource = Join-Path (Get-Location) "packages\clang.headers\include"
+    if (-not (Test-Path -Path $headersSource -PathType Container)) { Write-Error "Clang headers directory not found: $headersSource"; exit 1 }
+    Write-Host "Copying clang headers from '$headersSource' to '$clangResourceInclude'..."
+    Copy-Item -Path "$headersSource\*" -Destination $clangResourceInclude -Recurse -Force
     Write-Host "Clang builtin headers installed."
 
     # Copy any scripts that will be packaged into the output folder

--- a/scripts/onebranch/pre-build.ps1
+++ b/scripts/onebranch/pre-build.ps1
@@ -17,18 +17,18 @@ try {
 
     # Install LLVM tools (clang with BPF target support) for compiling eBPF programs.
     Write-Host "Installing LLVM tools..."
-    nuget install llvm.tools -OutputDirectory packages -version 19.1.4-34 -ExcludeVersion
-    if ($LASTEXITCODE -ne 0) { throw "Failed to install llvm.tools" }
-    nuget install clang.headers -OutputDirectory packages -version 19.1.4-34 -ExcludeVersion
-    if ($LASTEXITCODE -ne 0) { throw "Failed to install clang.headers" }
+nuget install llvm.tools -OutputDirectory packages -version 19.1.4-34 -ExcludeVersion
+if ($LASTEXITCODE -ne 0) { Write-Error "Failed to install llvm.tools (exit code $LASTEXITCODE)"; exit $LASTEXITCODE }
+nuget install clang.headers -OutputDirectory packages -version 19.1.4-34 -ExcludeVersion
+if ($LASTEXITCODE -ne 0) { Write-Error "Failed to install clang.headers (exit code $LASTEXITCODE)"; exit $LASTEXITCODE }
 
     # Add LLVM tools to PATH so clang is available for BPF compilation.
     $llvmPath = Join-Path (Get-Location) "packages\llvm.tools"
     $env:Path = "$llvmPath;$env:Path"
     Write-Host "##vso[task.prependpath]$llvmPath"
-    Write-Host "LLVM tools installed. Clang version:"
-    clang --version
-    if ($LASTEXITCODE -ne 0) { throw "Failed to run clang --version" }
+Write-Host "LLVM tools installed. Clang version:"
+& "$llvmPath\clang.exe" --version
+if ($LASTEXITCODE -ne 0) { Write-Error "Failed to run clang --version (exit code $LASTEXITCODE)"; exit $LASTEXITCODE }
 
     # Place clang builtin headers where the clang resource directory expects them.
     # clang --print-resource-dir resolves to <llvm.tools>\lib\clang\<major>, but the
@@ -41,9 +41,10 @@ try {
     if (-not (Test-Path $clangResourceInclude)) {
         New-Item -ItemType Directory -Path $clangResourceInclude -Force | Out-Null
     }
-    $headersSource = Join-Path (Get-Location) "packages\clang.headers\include"
-    Write-Host "Copying clang headers from '$headersSource' to '$clangResourceInclude'..."
-    Copy-Item -Path "$headersSource\*" -Destination $clangResourceInclude -Recurse -Force
+$headersSource = Join-Path (Get-Location) "packages\clang.headers\include"
+if (-not (Test-Path -Path $headersSource -PathType Container)) { Write-Error "Clang headers directory not found: $headersSource"; exit 1 }
+Write-Host "Copying clang headers from '$headersSource' to '$clangResourceInclude'..."
+Copy-Item -Path "$headersSource\*" -Destination $clangResourceInclude -Recurse -Force
     Write-Host "Clang builtin headers installed."
 
     # Copy any scripts that will be packaged into the output folder


### PR DESCRIPTION
## Description

Enables BPF program compilation and proper artifact publishing in the OneBranch NonProduction pipeline's full build stage.

## Testing

Internal CI/CD

## Documentation

N/A

## Installation

N/A