### PR TITLE
Fix update curl dependencies

### DIFF
--- a/.github/curl-dependencies.json
+++ b/.github/curl-dependencies.json
@@ -1,0 +1,10 @@
+{
+  "procdump": {
+    "url": "https://download.sysinternals.com/files/Procdump.zip",
+    "hash": "68E057587B0FD654EFA095F76D80D633C0E5C60EA26FD3E7C0011C076BB2D00C"
+  },
+  "opencppcoverage": {
+    "version": "release-0.9.9.0",
+    "hash": "2295A733DA39412C61E4F478677519DD0BB1893D88313CE56B468C9E50517888"
+  }
+}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -107,7 +107,7 @@ jobs:
       id: install_procdump
       if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
       run: |
-        $curlDependencies = Get-Content "${{github.workspace}}\.github\curl-dependencies.json" | ConvertFrom-Json
+        $curlDependencies = Get-Content -Raw "${{github.workspace}}\.github\curl-dependencies.json" | ConvertFrom-Json
         $url = $curlDependencies.procdump.url
         $expectedHash = $curlDependencies.procdump.hash
         $procDumpZipPath = "${{github.workspace}}\Procdump.zip"
@@ -124,7 +124,7 @@ jobs:
       id: set_up_opencppcoverage
       if: (inputs.code_coverage == true) && (inputs.environment != 'ebpf_cicd_tests_ws2019' && inputs.environment != 'ebpf_cicd_tests_ws2022' && inputs.environment != 'ebpf_cicd_perf_ws2022') && (steps.skip_check.outputs.should_skip != 'true')
       run: |
-        $curlDependencies = Get-Content "${{github.workspace}}\.github\curl-dependencies.json" | ConvertFrom-Json
+        $curlDependencies = Get-Content -Raw "${{github.workspace}}\.github\curl-dependencies.json" | ConvertFrom-Json
         $version = $curlDependencies.opencppcoverage.version
         $expectedHash = $curlDependencies.opencppcoverage.hash
         $versionNumber = $version -replace '^release-', ''

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -106,12 +106,12 @@ jobs:
     - name: Install ProcDump
       id: install_procdump
       if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
-      env:
-        # Hash of the latest ProcDump release from https://download.sysinternals.com/files/Procdump.zip
-        PROCDUMP_EXPECTED_HASH: '68E057587B0FD654EFA095F76D80D633C0E5C60EA26FD3E7C0011C076BB2D00C'
       run: |
+        $curlDependencies = Get-Content "${{github.workspace}}\.github\curl-dependencies.json" | ConvertFrom-Json
+        $url = $curlDependencies.procdump.url
+        $expectedHash = $curlDependencies.procdump.hash
         $procDumpZipPath = "${{github.workspace}}\Procdump.zip"
-        & ${{github.workspace}}\scripts\Download-AndVerify.ps1 -Url "https://download.sysinternals.com/files/Procdump.zip" -DestinationPath $procDumpZipPath -ExpectedHash $env:PROCDUMP_EXPECTED_HASH
+        & ${{github.workspace}}\scripts\Download-AndVerify.ps1 -Url $url -DestinationPath $procDumpZipPath -ExpectedHash $expectedHash
         Expand-Archive -Path $procDumpZipPath -DestinationPath ${{github.workspace}}\procdump -Force
         Remove-Item -Path $procDumpZipPath -Force
         echo "${{github.workspace}}\procdump" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -123,11 +123,14 @@ jobs:
     - name: Set up OpenCppCoverage and add to PATH
       id: set_up_opencppcoverage
       if: (inputs.code_coverage == true) && (inputs.environment != 'ebpf_cicd_tests_ws2019' && inputs.environment != 'ebpf_cicd_tests_ws2022' && inputs.environment != 'ebpf_cicd_perf_ws2022') && (steps.skip_check.outputs.should_skip != 'true')
-      env:
-        OPENCPPCOVERAGE_EXPECTED_HASH: '2295A733DA39412C61E4F478677519DD0BB1893D88313CE56B468C9E50517888'
       run: |
+        $curlDependencies = Get-Content "${{github.workspace}}\.github\curl-dependencies.json" | ConvertFrom-Json
+        $version = $curlDependencies.opencppcoverage.version
+        $expectedHash = $curlDependencies.opencppcoverage.hash
+        $versionNumber = $version -replace '^release-', ''
+        $url = "https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/$version/OpenCppCoverageSetup-x64-$versionNumber.exe"
         $setupPath = "${{github.workspace}}\OpenCppCoverageSetup.exe"
-        & ${{github.workspace}}\scripts\Download-AndVerify.ps1 -Url "https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/release-0.9.9.0/OpenCppCoverageSetup-x64-0.9.9.0.exe" -DestinationPath $setupPath -ExpectedHash $env:OPENCPPCOVERAGE_EXPECTED_HASH
+        & ${{github.workspace}}\scripts\Download-AndVerify.ps1 -Url $url -DestinationPath $setupPath -ExpectedHash $expectedHash
         Start-Process -FilePath $setupPath -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART' -Wait
         Remove-Item -Path $setupPath -Force
         echo "C:\Program Files\OpenCppCoverage" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -127,6 +127,7 @@ jobs:
         if ($expectedHash -notmatch '^[0-9A-Fa-f]{64}$') {
             throw "ProcDump expected hash is not a valid SHA256 hex digest: '$expectedHash'"
         }
+        $expectedHash = $expectedHash.ToUpperInvariant()
         $procDumpZipPath = "${{github.workspace}}\Procdump.zip"
         & ${{github.workspace}}\scripts\Download-AndVerify.ps1 -Url $url -DestinationPath $procDumpZipPath -ExpectedHash $expectedHash
         Expand-Archive -Path $procDumpZipPath -DestinationPath ${{github.workspace}}\procdump -Force
@@ -151,6 +152,7 @@ jobs:
         if ($expectedHash -notmatch '^[0-9A-Fa-f]{64}$') {
             throw "OpenCppCoverage expected hash is not a valid SHA256 hex digest: '$expectedHash'"
         }
+        $expectedHash = $expectedHash.ToUpperInvariant()
         $versionNumber = $version -replace '^release-', ''
         $url = "https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/$version/OpenCppCoverageSetup-x64-$versionNumber.exe"
         $setupPath = "${{github.workspace}}\OpenCppCoverageSetup.exe"

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -110,6 +110,23 @@ jobs:
         $curlDependencies = Get-Content -Raw "${{github.workspace}}\.github\curl-dependencies.json" | ConvertFrom-Json
         $url = $curlDependencies.procdump.url
         $expectedHash = $curlDependencies.procdump.hash
+        # Validate against a strict allowlist/format before downloading and executing anything on the runner.
+        $allowedHosts = @('download.sysinternals.com')
+        try {
+            $parsedUrl = [System.Uri]$url
+        } catch {
+            throw "ProcDump URL is not a valid URI: '$url'"
+        }
+        if ($parsedUrl.Scheme -ne 'https') {
+            throw "ProcDump URL must use https, got scheme '$($parsedUrl.Scheme)' in '$url'"
+        }
+        if ($allowedHosts -notcontains $parsedUrl.Host) {
+            throw "ProcDump URL host '$($parsedUrl.Host)' is not in the allowlist ($($allowedHosts -join ', '))"
+        }
+        # The expected hash must be exactly a 64-character hex SHA256 digest.
+        if ($expectedHash -notmatch '^[0-9A-Fa-f]{64}$') {
+            throw "ProcDump expected hash is not a valid SHA256 hex digest: '$expectedHash'"
+        }
         $procDumpZipPath = "${{github.workspace}}\Procdump.zip"
         & ${{github.workspace}}\scripts\Download-AndVerify.ps1 -Url $url -DestinationPath $procDumpZipPath -ExpectedHash $expectedHash
         Expand-Archive -Path $procDumpZipPath -DestinationPath ${{github.workspace}}\procdump -Force
@@ -127,6 +144,13 @@ jobs:
         $curlDependencies = Get-Content -Raw "${{github.workspace}}\.github\curl-dependencies.json" | ConvertFrom-Json
         $version = $curlDependencies.opencppcoverage.version
         $expectedHash = $curlDependencies.opencppcoverage.hash
+        # Validate the version and hash format strictly so that we don't allow arbitrary code execution.
+        if ($version -notmatch '^release-\d+(\.\d+){1,3}$') {
+            throw "OpenCppCoverage version is not in the expected 'release-X.Y.Z.W' format: '$version'"
+        }
+        if ($expectedHash -notmatch '^[0-9A-Fa-f]{64}$') {
+            throw "OpenCppCoverage expected hash is not a valid SHA256 hex digest: '$expectedHash'"
+        }
         $versionNumber = $version -replace '^release-', ''
         $url = "https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/$version/OpenCppCoverageSetup-x64-$versionNumber.exe"
         $setupPath = "${{github.workspace}}\OpenCppCoverageSetup.exe"

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -95,10 +95,13 @@ jobs:
         cancel_others: 'false'
         paths_ignore: '["**.md", "**/docs/**"]'
 
-    # Checking out the branch is needed to gather correct code coverage data.
+    # Checking out the branch is needed to gather correct code coverage data, and to make
+    # .github/curl-dependencies.json and scripts/Download-AndVerify.ps1 available for the
+    # ProcDump / OpenCppCoverage install steps.
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      # Only check out source code if code coverage is being gathered.
-      if: (inputs.code_coverage == true) && (steps.skip_check.outputs.should_skip != 'true')
+      # Check out source code if code coverage is being gathered or if crash dumps
+      # (which require ProcDump downloaded via the repo scripts) are being gathered.
+      if: ((inputs.code_coverage == true) || (inputs.gather_dumps == true)) && (steps.skip_check.outputs.should_skip != 'true')
       with:
         submodules: 'recursive'
         ref: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/update-curl-dependencies.yml
+++ b/.github/workflows/update-curl-dependencies.yml
@@ -15,9 +15,9 @@ name: Update curl-downloaded dependencies
 on:
   # Allow this workflow to be manually triggered.
   workflow_dispatch:
-  # Run this once a week on saturday at 9pm UTC.
+  # Run this everyday at 6am UTC.
   schedule:
-    - cron: '0 21 * * 6'
+    - cron: '0 6 * * *'
 
 permissions:
   contents: write

--- a/.github/workflows/update-curl-dependencies.yml
+++ b/.github/workflows/update-curl-dependencies.yml
@@ -73,6 +73,8 @@ jobs:
           else
             gh pr create --title "Update ProcDump hash" \
               --body "ProcDump zip hash changed from \`$OLD_HASH\` to \`$NEW_HASH\`." \
+              --base main --head "$BRANCH" || gh pr view "$BRANCH" --json number >/dev/null 2>&1
+          fi
               --base main --head "$BRANCH"
           fi
 

--- a/.github/workflows/update-curl-dependencies.yml
+++ b/.github/workflows/update-curl-dependencies.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           set -euo pipefail
           # Download current ProcDump and compute hash.
-          URL=$(jq -r '.procdump.url' .github/curl-dependencies.json)
+          URL=$(jq -er '.procdump.url' .github/curl-dependencies.json)
           curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 300 -o /tmp/Procdump.zip "$URL"
           test -s /tmp/Procdump.zip || { echo "ERROR: ProcDump download is empty"; exit 1; }
           NEW_HASH=$(sha256sum /tmp/Procdump.zip | awk '{print toupper($1)}')
@@ -93,7 +93,7 @@ jobs:
           LATEST=$(gh api repos/OpenCppCoverage/OpenCppCoverage/releases/latest \
             --jq '.tag_name')
           # Current version pinned in the dependency manifest.
-          CURRENT=$(jq -r '.opencppcoverage.version' .github/curl-dependencies.json)
+          CURRENT=$(jq -er '.opencppcoverage.version' .github/curl-dependencies.json)
 
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "latest=$LATEST" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-curl-dependencies.yml
+++ b/.github/workflows/update-curl-dependencies.yml
@@ -145,5 +145,7 @@ jobs:
           else
             gh pr create --title "Update OpenCppCoverage to $LATEST" \
               --body "Updates from \`$CURRENT\` to \`$LATEST\`. New hash: \`$NEW_HASH\`." \
+              --base main --head "$BRANCH" || gh pr view "$BRANCH" --json number >/dev/null 2>&1
+          fi
               --base main --head "$BRANCH"
           fi

--- a/.github/workflows/update-curl-dependencies.yml
+++ b/.github/workflows/update-curl-dependencies.yml
@@ -75,8 +75,6 @@ jobs:
               --body "ProcDump zip hash changed from \`$OLD_HASH\` to \`$NEW_HASH\`." \
               --base main --head "$BRANCH" || gh pr view "$BRANCH" --json number >/dev/null 2>&1
           fi
-              --base main --head "$BRANCH"
-          fi
 
   check-opencppcoverage:
     name: Check OpenCppCoverage for updates
@@ -146,6 +144,4 @@ jobs:
             gh pr create --title "Update OpenCppCoverage to $LATEST" \
               --body "Updates from \`$CURRENT\` to \`$LATEST\`. New hash: \`$NEW_HASH\`." \
               --base main --head "$BRANCH" || gh pr view "$BRANCH" --json number >/dev/null 2>&1
-          fi
-              --base main --head "$BRANCH"
           fi

--- a/.github/workflows/update-curl-dependencies.yml
+++ b/.github/workflows/update-curl-dependencies.yml
@@ -42,8 +42,7 @@ jobs:
           rm /tmp/Procdump.zip
 
           # Extract current hash from the dependency manifest.
-          OLD_HASH=$(jq -r '.procdump.hash' .github/curl-dependencies.json)
-
+          OLD_HASH=$(jq -er '.procdump.hash' .github/curl-dependencies.json)
           echo "old_hash=$OLD_HASH" >> "$GITHUB_OUTPUT"
           echo "new_hash=$NEW_HASH" >> "$GITHUB_OUTPUT"
           if [ "$OLD_HASH" != "$NEW_HASH" ]; then
@@ -113,7 +112,7 @@ jobs:
           NEW_HASH=$(sha256sum /tmp/setup.exe | awk '{print toupper($1)}')
           rm /tmp/setup.exe
 
-          OLD_HASH=$(jq -r '.opencppcoverage.hash' .github/curl-dependencies.json)
+          OLD_HASH=$(jq -er '.opencppcoverage.hash' .github/curl-dependencies.json)
 
           echo "new_hash=$NEW_HASH" >> "$GITHUB_OUTPUT"
           echo "old_hash=$OLD_HASH" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-curl-dependencies.yml
+++ b/.github/workflows/update-curl-dependencies.yml
@@ -3,6 +3,12 @@
 #
 # Checks for updates to dependencies downloaded via curl in CI workflows.
 # Currently monitors: ProcDump (Sysinternals), OpenCppCoverage.
+#
+# Versions and hashes live in .github/curl-dependencies.json (a regular,
+# non-workflow file) rather than inline in the workflow files. This lets the
+# built-in GITHUB_TOKEN push updates without the `workflow` scope, since no file
+# under .github/workflows/ is modified. Do not inline these values back into the
+# workflow files or this automation will fail to push.
 
 name: Update curl-downloaded dependencies
 
@@ -29,14 +35,14 @@ jobs:
         run: |
           set -euo pipefail
           # Download current ProcDump and compute hash.
-          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 300 -o /tmp/Procdump.zip https://download.sysinternals.com/files/Procdump.zip
+          URL=$(jq -r '.procdump.url' .github/curl-dependencies.json)
+          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 300 -o /tmp/Procdump.zip "$URL"
           test -s /tmp/Procdump.zip || { echo "ERROR: ProcDump download is empty"; exit 1; }
           NEW_HASH=$(sha256sum /tmp/Procdump.zip | awk '{print toupper($1)}')
           rm /tmp/Procdump.zip
 
-          # Extract current hash from workflow file.
-          OLD_HASH=$(grep -oP "PROCDUMP_EXPECTED_HASH: '\K[A-F0-9]+" \
-            .github/workflows/reusable-test.yml | head -1)
+          # Extract current hash from the dependency manifest.
+          OLD_HASH=$(jq -r '.procdump.hash' .github/curl-dependencies.json)
 
           echo "old_hash=$OLD_HASH" >> "$GITHUB_OUTPUT"
           echo "new_hash=$NEW_HASH" >> "$GITHUB_OUTPUT"
@@ -56,15 +62,20 @@ jobs:
           set -euo pipefail
           BRANCH="auto/update-procdump-hash"
           git switch -C "$BRANCH"
-          sed -i "s/$OLD_HASH/$NEW_HASH/g" .github/workflows/reusable-test.yml
+          jq --arg h "$NEW_HASH" '.procdump.hash = $h' .github/curl-dependencies.json > /tmp/deps.json
+          mv /tmp/deps.json .github/curl-dependencies.json
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .github/workflows/reusable-test.yml
+          git add .github/curl-dependencies.json
           git commit -m "Update ProcDump expected hash to $NEW_HASH"
           git push -f origin "$BRANCH"
-          gh pr create --title "Update ProcDump hash" \
-            --body "ProcDump zip hash changed from \`$OLD_HASH\` to \`$NEW_HASH\`." \
-            --base main --head "$BRANCH" || true
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "PR already exists for $BRANCH; skipping create."
+          else
+            gh pr create --title "Update ProcDump hash" \
+              --body "ProcDump zip hash changed from \`$OLD_HASH\` to \`$NEW_HASH\`." \
+              --base main --head "$BRANCH"
+          fi
 
   check-opencppcoverage:
     name: Check OpenCppCoverage for updates
@@ -81,9 +92,8 @@ jobs:
           # Get latest release tag from GitHub API.
           LATEST=$(gh api repos/OpenCppCoverage/OpenCppCoverage/releases/latest \
             --jq '.tag_name')
-          # Current version pinned in workflow.
-          CURRENT=$(grep -oP 'releases/download/\K[^/]+' \
-            .github/workflows/reusable-test.yml | head -1)
+          # Current version pinned in the dependency manifest.
+          CURRENT=$(jq -r '.opencppcoverage.version' .github/curl-dependencies.json)
 
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
@@ -103,8 +113,7 @@ jobs:
           NEW_HASH=$(sha256sum /tmp/setup.exe | awk '{print toupper($1)}')
           rm /tmp/setup.exe
 
-          OLD_HASH=$(grep -oP "OPENCPPCOVERAGE_EXPECTED_HASH: '\K[A-F0-9]+" \
-            .github/workflows/reusable-test.yml | head -1)
+          OLD_HASH=$(jq -r '.opencppcoverage.hash' .github/curl-dependencies.json)
 
           echo "new_hash=$NEW_HASH" >> "$GITHUB_OUTPUT"
           echo "old_hash=$OLD_HASH" >> "$GITHUB_OUTPUT"
@@ -119,19 +128,21 @@ jobs:
           NEW_HASH: ${{ steps.check.outputs.new_hash }}
         run: |
           set -euo pipefail
-          CURRENT_VERSION="${CURRENT#release-}"
-          LATEST_VERSION="${LATEST#release-}"
-
           BRANCH="auto/update-opencppcoverage"
           git switch -C "$BRANCH"
-          sed -i "s|$CURRENT|$LATEST|g" .github/workflows/reusable-test.yml
-          sed -i "s|OpenCppCoverageSetup-x64-$CURRENT_VERSION|OpenCppCoverageSetup-x64-$LATEST_VERSION|g" .github/workflows/reusable-test.yml
-          sed -i "s|$OLD_HASH|$NEW_HASH|g" .github/workflows/reusable-test.yml
+          jq --arg v "$LATEST" --arg h "$NEW_HASH" \
+            '.opencppcoverage.version = $v | .opencppcoverage.hash = $h' \
+            .github/curl-dependencies.json > /tmp/deps.json
+          mv /tmp/deps.json .github/curl-dependencies.json
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .github/workflows/reusable-test.yml
+          git add .github/curl-dependencies.json
           git commit -m "Update OpenCppCoverage to $LATEST"
           git push -f origin "$BRANCH"
-          gh pr create --title "Update OpenCppCoverage to $LATEST" \
-            --body "Updates from \`$CURRENT\` to \`$LATEST\`. New hash: \`$NEW_HASH\`." \
-            --base main --head "$BRANCH" || true
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "PR already exists for $BRANCH; skipping create."
+          else
+            gh pr create --title "Update OpenCppCoverage to $LATEST" \
+              --body "Updates from \`$CURRENT\` to \`$LATEST\`. New hash: \`$NEW_HASH\`." \
+              --base main --head "$BRANCH"
+          fi

--- a/.github/workflows/update-curl-dependencies.yml
+++ b/.github/workflows/update-curl-dependencies.yml
@@ -15,7 +15,7 @@ name: Update curl-downloaded dependencies
 on:
   # Allow this workflow to be manually triggered.
   workflow_dispatch:
-  # Run this everyday at 6am UTC.
+  # Run this every day at 6am UTC.
   schedule:
     - cron: '0 6 * * *'
 


### PR DESCRIPTION
## Description

Versions and hashes are now stored in .github/curl-dependencies.json (a regular, non-workflow file). This lets the built-in GITHUB_TOKEN push updates without needing the workflow scope, since no file under .github/workflows/ is modified.

## Testing

Workflow succeeds and opens a PR on my ebpf-for-windows fork.

## Documentation

No

## Installation

No
