### PR TITLE
Statically link C++ runtime

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,11 +62,13 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <!-- Statically link the C++ runtime so the VC++ redistributable is not required at deployment. -->
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WholeProgramOptimization Condition="'$(EnableAsan)' != 'true'">true</WholeProgramOptimization>
     </ClCompile>
     <Link>
-      <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/spgo %(AdditionalOptions)</AdditionalOptions>
+      <!-- Keep the Universal CRT dynamically linked (ucrtbase.dll ships with the OS) instead of static libucrt.lib. -->
+      <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib /spgo %(AdditionalOptions)</AdditionalOptions>
       <LinkTimeCodeGeneration Condition="'$(EnableAsan)' != 'true'">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
@@ -74,8 +76,13 @@
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <!-- Statically link the C++ runtime so the VC++ redistributable is not required at deployment. -->
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
+    <Link>
+      <!-- Keep the Universal CRT dynamically linked (ucrtbased.dll) instead of static libucrtd.lib. -->
+      <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib %(AdditionalOptions)</AdditionalOptions>
+    </Link>
   </ItemDefinitionGroup>
   <PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.csproj'">
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)\RunSettings.runsettings</RunSettingsFilePath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,12 +64,12 @@
     <ClCompile>
       <!-- Statically link the C++ runtime so the VC++ redistributable is not required at deployment. -->
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <WholeProgramOptimization Condition="'$(EnableAsan)' != 'true'">true</WholeProgramOptimization>
+      <WholeProgramOptimization Condition="'$(EnableASAN)' != 'true'">true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <!-- Keep the Universal CRT dynamically linked (ucrtbase.dll ships with the OS) instead of static libucrt.lib. -->
       <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib /spgo %(AdditionalOptions)</AdditionalOptions>
-      <LinkTimeCodeGeneration Condition="'$(EnableAsan)' != 'true'">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration Condition="'$(EnableASAN)' != 'true'">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">

--- a/external/Directory.Build.props
+++ b/external/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Fuzzer)'=='True' OR '$(Configuration)'=='FuzzerDebug'">
     <AdditionalOptions>/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
-    <FuzzerLibs>libsancov.lib;clang_rt.fuzzer_MDd-x86_64.lib</FuzzerLibs>
+    <FuzzerLibs>libsancov.lib;clang_rt.fuzzer_MTd-x86_64.lib</FuzzerLibs>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
@@ -24,12 +24,14 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <!-- Statically link the C++ runtime so the VC++ redistributable is not required at deployment. -->
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WholeProgramOptimization Condition="'$(EnableASAN)' != 'true'">true</WholeProgramOptimization>
       <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/spgo %(AdditionalOptions)</AdditionalOptions>
+      <!-- Keep the Universal CRT dynamically linked (ucrtbase.dll ships with the OS) instead of static libucrt.lib. -->
+      <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib /spgo %(AdditionalOptions)</AdditionalOptions>
       <LinkTimeCodeGeneration Condition="'$(EnableASAN)' != 'true'">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
@@ -37,8 +39,13 @@
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <!-- Statically link the C++ runtime so the VC++ redistributable is not required at deployment. -->
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
+    <Link>
+      <!-- Keep the Universal CRT dynamically linked (ucrtbased.dll) instead of static libucrtd.lib. -->
+      <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib %(AdditionalOptions)</AdditionalOptions>
+    </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/scripts/deploy-ebpf.ps1.in
+++ b/scripts/deploy-ebpf.ps1.in
@@ -282,13 +282,11 @@ OPTIONS:
     { @("-t", "--test") -contains $_ }
         {
             $built_files= $built_runtime_files + $built_test_files
-            $copy_redist=$true
             break
         }
     { @("-j", "--jittest") -contains $_ }
         {
             $built_files= $built_runtime_files + $built_runtime_jit_files + $built_test_files
-            $copy_redist=$true
             break
         }
     default
@@ -312,21 +310,6 @@ if ($vm -eq $null) {
          New-Item -Type Directory $destination_full_directory -ErrorAction Stop | Write-Verbose
       }
       Copy-Item "$source_path" -Destination "$destination_path" -ErrorAction Stop
-   }
-
-   if ($copy_redist) {
-      Write-Host "Copying the VC++ Redist (Debug) files from `"$vc_redist_dir`" to `"$destination_directory`""
-      $files = Get-ChildItem -Path $vc_redist_dir -File
-      foreach ($file in $files) {
-        $source_path = $file.FullName
-        $destination_path = Join-Path -Path $destination_directory -ChildPath $file.Name
-        $destination_full_directory = Split-Path $destination_path -Parent
-        Write-Host " $source_path -> $destination_path"
-        if (!(Test-Path $destination_full_directory)) {
-          New-Item -Type Directory $destination_full_directory -ErrorAction Stop | Write-Verbose
-        }
-        Copy-Item -Path $source_path -Destination $destination_path -ErrorAction Stop
-      }
    }
 
    Write-Host "Copying files from `"$source_directory`" to `"$destination_directory`""
@@ -377,18 +360,4 @@ foreach ( $file in $source_files ) {
    if (! $?) {
        exit 1
    }
-}
-
-if ($copy_redist) {
-    Write-Host "Copying the VC++ Redist (Debug) files from `"$vc_redist_dir`" to `"$destination_directory`" in VM `"$vm`"..."
-    $files = Get-ChildItem -Path $vc_redist_dir -File
-    foreach ($file in $files) {
-        $source_path = $file.FullName
-        $destination_path = Join-Path -Path $destination_directory -ChildPath $file.Name
-        Write-Host " $source_path -> $destination_path"
-        Copy-VMFile "$vm" -SourcePath "$source_path" -DestinationPath "$destination_path" -CreateFullPath -FileSource Host -Force
-        if (! $?) {
-            exit 1
-        }
-    }
 }

--- a/scripts/deploy-ebpf.ps1.in
+++ b/scripts/deploy-ebpf.ps1.in
@@ -224,8 +224,6 @@ $source_directory="."
 $destination_directory="C:\Temp"
 $error.clear()
 $vm="Windows 10 dev environment"
-$vc_redist_dir = Join-Path -Path $env:VCToolsRedistDir '\debug_nonredist\x64\Microsoft.VC143.DebugCRT\'
-$copy_redist=$false
 
 ##
 ## Process command-line options

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -15,7 +15,7 @@ $exportProgramInfoPath = ".\packages\eBPF-for-Windows.x64.$ebpfVersion\build\nat
 # Define the commands to run
 $commands = @(
     "git submodule update --init --recursive",
-    'cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded`$<`$<CONFIG:Debug>:Debug>`$<`$<CONFIG:FuzzerDebug>:Debug>',
+    'cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded`$<`$<CONFIG:Debug>:Debug>`$<`$<CONFIG:FuzzerDebug>:Debug>"',
     "nuget restore ntosebpfext.sln",
     "dotnet restore ntosebpfext.sln",
     $exportProgramInfoPath

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -15,7 +15,7 @@ $exportProgramInfoPath = ".\packages\eBPF-for-Windows.x64.$ebpfVersion\build\nat
 # Define the commands to run
 $commands = @(
     "git submodule update --init --recursive",
-    'cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>',
+    'cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded`$<`$<CONFIG:Debug>:Debug>`$<`$<CONFIG:FuzzerDebug>:Debug>',
     "nuget restore ntosebpfext.sln",
     "dotnet restore ntosebpfext.sln",
     $exportProgramInfoPath

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -12,10 +12,13 @@ Set-Location $scriptPath\..
 $ebpfVersion = $props.Project.PropertyGroup.eBPFForWindowsVersion
 $exportProgramInfoPath = ".\packages\eBPF-for-Windows.x64.$ebpfVersion\build\native\bin\export_program_info.exe"
 
-# Define the commands to run
+# Define the commands to run. String entries are run via Invoke-Expression; script block
+# entries are invoked directly so their arguments are not re-parsed by the shell. The cmake
+# call must be a script block because the CMake generator expression contains '<' and '>'
+# characters that Invoke-Expression would otherwise treat as redirection operators.
 $commands = @(
     "git submodule update --init --recursive",
-    'cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>',
+    { & cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>' },
     "nuget restore ntosebpfext.sln",
     "dotnet restore ntosebpfext.sln",
     $exportProgramInfoPath
@@ -24,7 +27,11 @@ $commands = @(
 # Loop through each command and run them sequentially without opening a new window
 foreach ($command in $commands) {
     Write-Host ">> Running command: $command"
-    Invoke-Expression -Command $command
+    if ($command -is [scriptblock]) {
+        & $command
+    } else {
+        Invoke-Expression -Command $command
+    }
 
     # Check the exit code
     if ($LASTEXITCODE -ne 0) {

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -15,7 +15,7 @@ $exportProgramInfoPath = ".\packages\eBPF-for-Windows.x64.$ebpfVersion\build\nat
 # Define the commands to run
 $commands = @(
     "git submodule update --init --recursive",
-    "cmake -G 'Visual Studio 17 2022' -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF",
+    "cmake -G 'Visual Studio 17 2022' -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>'",
     "nuget restore ntosebpfext.sln",
     "dotnet restore ntosebpfext.sln",
     $exportProgramInfoPath

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -15,7 +15,7 @@ $exportProgramInfoPath = ".\packages\eBPF-for-Windows.x64.$ebpfVersion\build\nat
 # Define the commands to run
 $commands = @(
     "git submodule update --init --recursive",
-'cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>',
+    'cmake --% -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>',
     "nuget restore ntosebpfext.sln",
     "dotnet restore ntosebpfext.sln",
     $exportProgramInfoPath

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -15,7 +15,7 @@ $exportProgramInfoPath = ".\packages\eBPF-for-Windows.x64.$ebpfVersion\build\nat
 # Define the commands to run
 $commands = @(
     "git submodule update --init --recursive",
-    "cmake -G 'Visual Studio 17 2022' -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>'",
+    'cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>',
     "nuget restore ntosebpfext.sln",
     "dotnet restore ntosebpfext.sln",
     $exportProgramInfoPath

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -15,7 +15,7 @@ $exportProgramInfoPath = ".\packages\eBPF-for-Windows.x64.$ebpfVersion\build\nat
 # Define the commands to run
 $commands = @(
     "git submodule update --init --recursive",
-    'cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded`$<`$<CONFIG:Debug>:Debug>`$<`$<CONFIG:FuzzerDebug>:Debug>"',
+'cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>',
     "nuget restore ntosebpfext.sln",
     "dotnet restore ntosebpfext.sln",
     $exportProgramInfoPath

--- a/scripts/initialize_repo.ps1
+++ b/scripts/initialize_repo.ps1
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 
+# Make PowerShell-level errors (e.g., command not found, parse errors) terminating so they
+# raise exceptions instead of merely writing to the error stream. Without this, a stale
+# $LASTEXITCODE from a previous native command could make a failed step look successful.
+$ErrorActionPreference = "Stop"
+
 # Get the path where this script is located
 $scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
@@ -27,13 +32,27 @@ $commands = @(
 # Loop through each command and run them sequentially without opening a new window
 foreach ($command in $commands) {
     Write-Host ">> Running command: $command"
-    if ($command -is [scriptblock]) {
-        & $command
-    } else {
-        Invoke-Expression -Command $command
+
+    # Reset $LASTEXITCODE so a stale value from a previous native command cannot be
+    # mistaken for success if this step fails before setting its own exit code.
+    $global:LASTEXITCODE = 0
+
+    try {
+        if ($command -is [scriptblock]) {
+            & $command
+        } else {
+            Invoke-Expression -Command $command
+        }
+    } catch {
+        # A PowerShell-level failure (command not found, parse error, etc.) throws here.
+        Write-Host "Command failed: $($_.Exception.Message)"
+        if ($LASTEXITCODE -ne 0) {
+            Exit $LASTEXITCODE
+        }
+        Exit 1
     }
 
-    # Check the exit code
+    # Check the exit code for native command failures that do not throw.
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Command failed. Exit code: $LASTEXITCODE"
         Exit  $LASTEXITCODE


### PR DESCRIPTION
Resolves: #286 

## Description

The eBPF extensions and export tools (`export_program_info.exe`, `netevent_monitor.exe`, and the
user-mode extension libraries) were compiled with `RuntimeLibrary = MultiThreadedDLL`, which
dynamically links the Visual C++ runtime (`msvcp140.dll` / `vcruntime140.dll`). Those DLLs are not
present on a clean Windows install, so running the tools without first installing the VC++
redistributable failed.

This change switches to **statically linking the C++ runtime** while **keeping the Universal CRT
(UCRT) dynamically linked**. The UCRT (`ucrtbase.dll`) is a Windows OS component present on all
supported versions, so linking it statically is unnecessary and discouraged. This mirrors the
approach already taken upstream in ebpf-for-windows
([#4460](https://github.com/microsoft/ebpf-for-windows/pull/4460)).

### Changes

- `Directory.Build.props`, `external/Directory.Build.props`,
  `external/ebpf-extension-common/Directory.Build.props`:
  - `MultiThreadedDLL` → `MultiThreaded` (Release) and `MultiThreadedDebugDLL` → `MultiThreadedDebug` (Debug).
  - Added linker options to keep the UCRT dynamic:
    `/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib` (Release) and
    `/NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib` (Debug).
  - UCRT override is guarded by `EnableASAN != 'true'` so ASAN/fuzzer builds keep their required
    dynamic runtime.
- `external/Directory.Build.props`: updated the fuzzer runtime lib
  `clang_rt.fuzzer_MDd-x86_64.lib` → `clang_rt.fuzzer_MTd-x86_64.lib` to match the now-static CRT.
- `scripts/deploy-ebpf.ps1.in`: removed the now-obsolete debug VC++ redist copy logic
  (`$copy_redist` / `$vc_redist_dir`). `ucrtbased.dll` is still copied for Debug since the UCRT
  remains dynamic.

## Testing

CI/CD. In addition, verified that the built user-mode binaries no longer depend on the VC++ runtime:

```powershell
dumpbin /dependents export_program_info.exe
```
• Before: lists  msvcp140.dll  /  vcruntime140.dll .
• After: no  msvcp140.dll  /  vcruntime140.dll  (only  ucrtbase.dll  + OS DLLs); no LNK4098
warnings during the build.

End-to-end: the export tool runs on a clean Windows VM with no VC++ redistributable installed.

Documentation

No.

Installation

No.