### PR TITLE
Resolve WDK/toolset selection by MSBuild version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,13 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
     <CodeAnalysisRuleSet>$(SolutionDir)Analyze.default.ruleset</CodeAnalysisRuleSet>
-    <!-- VS2026 (VisualStudioVersion 18.x) ships an analysis engine that emits a spurious C28285
+    <!-- VS2026 (MSBuild 18.x) ships an analysis engine that emits a spurious C28285
          on compiler-internal SAL_range intrinsics. Use a ruleset that relaxes C28285 to Warning
-         only for VS2026, keeping it as Error for VS2022 (17.x). -->
-    <CodeAnalysisRuleSet Condition="'$(VisualStudioVersion)' &gt;= '18.0'">$(SolutionDir)Analyze.vs2026.ruleset</CodeAnalysisRuleSet>
+         only for VS2026, keeping it as Error for VS2022 (MSBuild 17.x). Gated on
+         $(MSBuildAssemblyVersion) rather than $(VisualStudioVersion) for the reason documented in
+         wdk.props: $(VisualStudioVersion) is empty for a direct msbuild.exe invocation, which would
+         silently keep the VS2022 ruleset under VS2026 and fail the build on that spurious C28285. -->
+    <CodeAnalysisRuleSet Condition="'$(MSBuildAssemblyVersion)' &gt;= '18.0'">$(SolutionDir)Analyze.vs2026.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup>
     <eBPFExtensionsVersionMajor>0</eBPFExtensionsVersionMajor>

--- a/scripts/onebranch/post-build.ps1
+++ b/scripts/onebranch/post-build.ps1
@@ -24,8 +24,21 @@ Compress-Archive -Path $SignedOutputFolder -DestinationPath $OutputZipFile
 xcopy /y $SignedOutputFolder $BuildFolder
 
 # Create the nuget package with the signed binaries.
-Import-Module "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
-Enter-VsDevShell -VsInstallPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"  -DevCmdArguments "-arch=x64 -host_arch=x64"
+# Resolve the Visual Studio installation via vswhere rather than hardcoding a version-specific path.
+# The OneBranch build container ships whichever Visual Studio the image was built with (VS 2022 lives
+# under "...\2022\Enterprise", VS 2026 under "...\18\Enterprise"), so a literal path breaks whenever
+# the image is updated. This also puts msbuild on PATH for the packaging step below.
+$vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vswherePath)) {
+    throw "vswhere.exe not found at '$vswherePath'; unable to locate a Visual Studio installation."
+}
+$vsInstallPath = & $vswherePath -latest -products * -property installationPath | Select-Object -First 1
+if (-not $vsInstallPath) {
+    throw "Could not locate a Visual Studio installation via vswhere."
+}
+Write-Host "Using Visual Studio installation at '$vsInstallPath'."
+Import-Module (Join-Path $vsInstallPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+Enter-VsDevShell -VsInstallPath $vsInstallPath -DevCmdArguments "-arch=x64 -host_arch=x64"
 Set-Location $scriptPath\..\..
 $SolutionDir = Get-Location
 msbuild /p:SolutionDir=$SolutionDir\ /p:Configuration=$OneBranchConfig /p:Platform=$OneBranchArch /p:BuildProjectReferences=false .\tools\nuget\nuget.proj /t:Restore,Build,Pack

--- a/wdk.props
+++ b/wdk.props
@@ -6,28 +6,39 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
-    <!-- Visual Studio 2026 (18.0+) requires the newer WDK; Visual Studio 2022 uses the prior WDK.
-         The matching NuGet packages for both versions are listed in scripts\setup_build\packages.config
-         so the imports below resolve to whichever toolset is active. -->
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.26100.0</WindowsTargetPlatformVersion>
-    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
-    <WDKVersion Condition="'$(WDKVersion)' == ''">10.0.26100.4204</WDKVersion>
+    <!-- Visual Studio 2026 (MSBuild 18.0+) requires the newer WDK; Visual Studio 2022 (MSBuild 17)
+         uses the prior WDK. The matching NuGet packages for both versions are listed in
+         scripts\setup_build\packages.config so the imports below resolve to whichever toolset is active.
+
+         These gate on $(MSBuildAssemblyVersion) rather than $(VisualStudioVersion). $(VisualStudioVersion)
+         is only populated when the build is launched from a Developer Command Prompt / VS and is empty
+         when msbuild.exe is invoked directly, which silently selected the VS2022 WDK under MSBuild 18.
+         That produced a mismatched pair (target platform 10.0.28000.0 with WDK 10.0.26100.4204) and
+         failed with MSB4062 loading Microsoft.DriverKit.Build.Tasks.18.0.dll, an assembly the 26100
+         package does not ship, plus MSB8036 for the missing 10.0.28000.0 SDK. $(MSBuildAssemblyVersion)
+         is always defined and is the same value the WDK targets use to pick that task assembly.
+
+         The fallbacks are explicitly conditioned on '&lt; 18.0' rather than left unconditional so an
+         unexpected toolset version fails loudly instead of silently selecting the VS2022 WDK. -->
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">10.0.28000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">10.0.26100.0</WindowsTargetPlatformVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">10.0.28000.1839</WDKVersion>
+    <WDKVersion Condition="'$(WDKVersion)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">10.0.26100.4204</WDKVersion>
     <!-- Default platform toolset for user-mode projects. Visual Studio 2026 (MSBuild 18) uses v145;
          Visual Studio 2022 (MSBuild 17) uses v143. Kernel-mode projects override this with
          WindowsKernelModeDriver10.0 in their own Configuration PropertyGroups. Keeping this in lockstep
          with the WDK/target-platform selection above ensures Catch2 (built by the matching CMake
          generator) and the user-mode projects share one toolset, avoiding STL link mismatches. -->
-    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">v145</EbpfPlatformToolset>
-    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == ''">v143</EbpfPlatformToolset>
+    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">v145</EbpfPlatformToolset>
+    <EbpfPlatformToolset Condition="'$(EbpfPlatformToolset)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">v143</EbpfPlatformToolset>
     <!-- Platform toolset consumed by the ebpf-extension-common submodule. Its Directory.Build.props
          imports "$(SolutionDir)wdk.props", which resolves to THIS file when the submodule is built as
          part of ntosebpfext.sln, so the toolset variable its vcxproj files reference
          ($(EbpfExtPlatformToolset)) must be defined here. Kept in lockstep with $(EbpfPlatformToolset)
          so the submodule's user-mode lib and the consuming unit-test objects share one toolset
          (mismatched toolsets cause C1047 under Release LTCG). -->
-    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(VisualStudioVersion)' &gt;= '18.0'">v145</EbpfExtPlatformToolset>
-    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == ''">v143</EbpfExtPlatformToolset>
+    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(MSBuildAssemblyVersion)' &gt;= '18.0'">v145</EbpfExtPlatformToolset>
+    <EbpfExtPlatformToolset Condition="'$(EbpfExtPlatformToolset)' == '' and '$(MSBuildAssemblyVersion)' &lt; '18.0'">v143</EbpfExtPlatformToolset>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.$(WDKVersion)\build\native\Microsoft.Windows.SDK.cpp.props')" />


### PR DESCRIPTION
## Description

Related to [ebpf-for-windows/#5483](https://github.com/microsoft/ebpf-for-windows/issues/5483)

Three related VS2026 readiness fixes, needed before the OneBranch pipelines move to the ltsc2025/vse2026 container.

wdk.props / Directory.Build.props: gate the WDK, Windows SDK, platform toolset and code analysis ruleset selection on `$(MSBuildAssemblyVersion)` instead of `$(VisualStudioVersion)`, and give the fallbacks an explicit '< 18.0' condition instead of leaving them unconditional.

`$(MSBuildAssemblyVersion)` is always defined, is numeric, and reports the MSBuild major version ("17.0" / "18.0"). `$(VisualStudioVersion)` is only guaranteed when the build is driven by VS or a Developer Command Prompt. With the previous unconditional fallbacks, any value other than the exact expected one silently selected the VS2022 WDK, which under MSBuild 18 produces a mismatched pair (target platform 10.0.28000.0 with WDK 10.0.26100.4204) and fails with MSB4062 while loading Microsoft.DriverKit.Build.Tasks.18.0.dll, plus MSB8036 for the missing 10.0.28000.0 SDK.

Note `$(MSBuildToolsVersion)` is NOT a valid discriminator here: it evaluates to the string "Current" on both VS2022 and VS2026, so a '>= 18.0' test never distinguishes the two and can raise MSB4086.

scripts/onebranch/post-build.ps1: resolve the Visual Studio installation with vswhere rather than hardcoding
"C:\Program Files\Microsoft Visual Studio\2022\Enterprise". VS 2026 installs to "...\18\Enterprise", so the literal path fails on the new container with a missing Microsoft.VisualStudio.DevShell.dll. The Enter-VsDevShell call also puts msbuild on PATH for the nuget packaging step that follows, so it is retained rather than removed.

Verified by evaluating wdk.props with MSBuild 18: 17.0 selects v143 + WDK 10.0.26100.4204, 18.0 selects v145 + WDK 10.0.28000.1839.

## Testing

CI/CD

## Documentation

No

## Installation

No
